### PR TITLE
Moving the error check and handling to inside the files loop

### DIFF
--- a/src/PhpGitHooks/Infrastructure/CodeSniffer/CodeSnifferHandler.php
+++ b/src/PhpGitHooks/Infrastructure/CodeSniffer/CodeSnifferHandler.php
@@ -35,13 +35,13 @@ class CodeSnifferHandler extends ToolHandler
             /** @var Process $phpCs */
             $phpCs = $processBuilder->getProcess();
             $phpCs->run();
-        }
+            
+            if (false === $phpCs->isSuccessful()) {
+                $this->outputHandler->setError($phpCs->getOutput());
+                $this->output->writeln($this->outputHandler->getError());
 
-        if (false === $phpCs->isSuccessful()) {
-            $this->outputHandler->setError($phpCs->getOutput());
-            $this->output->writeln($this->outputHandler->getError());
-
-            throw new InvalidCodingStandardException();
+                throw new InvalidCodingStandardException();
+            }
         }
 
         $this->output->writeln($this->outputHandler->getSuccessfulStepMessage());


### PR DESCRIPTION
This is so that it only runs if there are php files to process (it errors when the hook runs when there are no php files in the commit)