### PR TITLE
Changed the PHP location on the shebang line

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 
 require __DIR__ . '/../../vendor/autoload.php';


### PR DESCRIPTION
Hi,

I've found that using the default PHP binary location don't always work. For all those people that work with some sort of a package manager, like Homebrew, that installs the binary on another location different than ```/usr/bin/php```, the pre-commit hook will not work as expected potentially executing a different PHP binary with a different PHP version. So this PR addresses this issue.

Best,
Christian.