### PR TITLE
Allow to install php-git-hooks globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ Library based in git hook scripts for PHP projects.
 
 ### Step 1: Composer
 
+If you don't have composer, you need download the  binary file and run it:
+
+```bash
+wget http://getcomposer.org/composer.phar
+# or
+curl -O http://getcomposer.org/composer.phar
+
+php composer.phar install
+```
+
+#### Local install (in a project)
+
 You must add the following line to the `composer.json` file:
 
 ```json
@@ -31,14 +43,16 @@ Or you can write in your console:
 $ composer require bruli/php-git-hooks --dev
 ```
 
-If you don't have composer, you need download the  binary file and run it:
+#### [Global install](https://getcomposer.org/doc/03-cli.md#global)
+
+Global installation can be usefull if you work on large number of repos which use the same dev dependencies or in continuous integration environment like Jenkins.
+
+Write same lines as local installation but in global composer file which should be in `~/.composer/` directory by [default](https://getcomposer.org/doc/03-cli.md#composer-home).
+
+Or you can write in your console:
 
 ```bash
-wget http://getcomposer.org/composer.phar
-# or
-curl -O http://getcomposer.org/composer.phar
-
-php composer.phar install
+$ composer global require bruli/php-git-hooks --dev
 ```
 
 ## Step 2: Configuration
@@ -75,7 +89,7 @@ If your project haven't a "bin" directory, you can add this in your compose.json
     }
 ```
 
-**Note: Not necessary for Symfony projects.**
+**Note: Not necessary for Symfony projects or in global installation.**
 
 ### Manual config file for git hooks.
 You can configure php-git-hooks, creating a php-git-hooks.yml file with...
@@ -106,6 +120,8 @@ commit-msg:
 
 ... or you can copy php-git-hooks.yml.sample from vendor/bruli/php-git-hooks.
 
+Manual configuration is necessary in global installation.
+
 ### Update from v1.3.*
 
 Php-cs-fixer configuration in php-git-hooks.yml file, is not compatible with 2.0 version. 
@@ -132,10 +148,24 @@ You can enable this hooks with composer or manually executing
  $cp vendor/bruli/php-git-hooks/hooks/pre-commit .git/hooks
 ```
 
+Global installation:
+
+```bash
+$ ln -s ~/.composer/vendor/bruli/php-git-hooks/hooks/pre-commit .git/hooks
+```
+
 #For commit-msg hook:
+
+Local installation:
 
 ```bash
  $cp vendor/bruli/php-git-hooks/hooks/commit-msg .git/hooks
+```
+
+Global installation:
+
+```bash
+$ ln -s ~/.composer/vendor/bruli/php-git-hooks/hooks/commit-msg .git/hooks
 ```
 
 ### execute.

--- a/hooks/bootstrap.php
+++ b/hooks/bootstrap.php
@@ -1,0 +1,25 @@
+<?php
+
+$binDir = 'bin';
+$home = false;
+if (false !== getenv('HOME')) {
+    $home = getenv('HOME') . '/.composer';
+}
+
+if (false !== getenv('COMPOSER_HOME')) {
+    $home = getenv('COMPOSER_HOME');
+}
+
+$autoload = __DIR__ . '/../../vendor/autoload.php';
+
+if (
+    false !== $home &&
+    false !== preg_match('~' . $home . '~', __DIR__)
+) {
+    $binDir = $home . '/vendor/bin';
+    $autoload = __DIR__ . '/../../../../vendor/autoload.php';
+}
+
+define('PHPGITHOOKS_BIN_DIR', $binDir);
+
+require $autoload;

--- a/hooks/bootstrap.php
+++ b/hooks/bootstrap.php
@@ -14,7 +14,7 @@ $autoload = __DIR__ . '/../../vendor/autoload.php';
 
 if (
     false !== $home &&
-    false !== preg_match('~' . $home . '~', __DIR__)
+    0 !== preg_match('~' . $home . '~', __DIR__)
 ) {
     $binDir = $home . '/vendor/bin';
     $autoload = __DIR__ . '/../../../../vendor/autoload.php';

--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -1,7 +1,7 @@
 #!/usr/bin/php
 <?php
 
-require __DIR__ . '/../../vendor/autoload.php';
+require __DIR__ . '/bootstrap.php';
 
 use PhpGitHooks\Command\QualityMessageTool;
 

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 
-require __DIR__ . '/../../vendor/autoload.php';
+require __DIR__ . '/bootstrap.php';
 
 use PhpGitHooks\Command\QualityCodeTool;
 

--- a/src/PhpGitHooks/Infrastructure/CodeSniffer/CodeSnifferHandler.php
+++ b/src/PhpGitHooks/Infrastructure/CodeSniffer/CodeSnifferHandler.php
@@ -7,6 +7,10 @@ use PhpGitHooks\Infrastructure\Common\ToolHandler;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\ProcessBuilder;
 
+if (!defined('PHPGITHOOKS_BIN_DIR')) {
+    define('PHPGITHOOKS_BIN_DIR', 'bin');
+}
+
 /**
  * Class CodeSnifferHandler.
  */

--- a/src/PhpGitHooks/Infrastructure/CodeSniffer/CodeSnifferHandler.php
+++ b/src/PhpGitHooks/Infrastructure/CodeSniffer/CodeSnifferHandler.php
@@ -32,7 +32,7 @@ class CodeSnifferHandler extends ToolHandler
                 continue;
             }
 
-            $processBuilder = new ProcessBuilder(array('php', PHPGITHOOKS_BIN_DIR . 'bin/phpcs', '--standard='.$this->standard, $file));
+            $processBuilder = new ProcessBuilder(array('php', PHPGITHOOKS_BIN_DIR . '/phpcs', '--standard='.$this->standard, $file));
             /** @var Process $phpCs */
             $phpCs = $processBuilder->getProcess();
             $phpCs->run();

--- a/src/PhpGitHooks/Infrastructure/CodeSniffer/CodeSnifferHandler.php
+++ b/src/PhpGitHooks/Infrastructure/CodeSniffer/CodeSnifferHandler.php
@@ -32,7 +32,7 @@ class CodeSnifferHandler extends ToolHandler
                 continue;
             }
 
-            $processBuilder = new ProcessBuilder(array('php', 'bin/phpcs', '--standard='.$this->standard, $file));
+            $processBuilder = new ProcessBuilder(array('php', PHPGITHOOKS_BIN_DIR . 'bin/phpcs', '--standard='.$this->standard, $file));
             /** @var Process $phpCs */
             $phpCs = $processBuilder->getProcess();
             $phpCs->run();

--- a/src/PhpGitHooks/Infrastructure/JsonLint/JsonLintHandler.php
+++ b/src/PhpGitHooks/Infrastructure/JsonLint/JsonLintHandler.php
@@ -29,7 +29,7 @@ final class JsonLintHandler extends ToolHandler implements RecursiveToolInterfac
             $processBuilder = new ProcessBuilder(
                 array(
                     'php',
-                    'bin/jsonlint',
+                    PHPGITHOOKS_BIN_DIR . '/jsonlint',
                     $file
                 )
             );

--- a/src/PhpGitHooks/Infrastructure/JsonLint/JsonLintHandler.php
+++ b/src/PhpGitHooks/Infrastructure/JsonLint/JsonLintHandler.php
@@ -7,6 +7,10 @@ use PhpGitHooks\Infrastructure\Common\RecursiveToolInterface;
 use PhpGitHooks\Infrastructure\Common\ToolHandler;
 use Symfony\Component\Process\ProcessBuilder;
 
+if (!defined('PHPGITHOOKS_BIN_DIR')) {
+    define('PHPGITHOOKS_BIN_DIR', 'bin');
+}
+
 final class JsonLintHandler extends ToolHandler implements RecursiveToolInterface
 {
     /** @var array  */

--- a/src/PhpGitHooks/Infrastructure/PhpCsFixer/PhpCsFixerHandler.php
+++ b/src/PhpGitHooks/Infrastructure/PhpCsFixer/PhpCsFixerHandler.php
@@ -38,7 +38,7 @@ class PhpCsFixerHandler extends ToolHandler implements InteractiveToolInterface,
                     $processBuilder = new ProcessBuilder(
                         array(
                             'php',
-                            'bin/php-cs-fixer',
+                            PHPGITHOOKS_BIN_DIR . '/php-cs-fixer',
                             '--dry-run',
                             'fix',
                             $file,

--- a/src/PhpGitHooks/Infrastructure/PhpCsFixer/PhpCsFixerHandler.php
+++ b/src/PhpGitHooks/Infrastructure/PhpCsFixer/PhpCsFixerHandler.php
@@ -7,6 +7,10 @@ use PhpGitHooks\Infrastructure\Common\InteractiveToolInterface;
 use PhpGitHooks\Infrastructure\Common\ToolHandler;
 use Symfony\Component\Process\ProcessBuilder;
 
+if (!defined('PHPGITHOOKS_BIN_DIR')) {
+    define('PHPGITHOOKS_BIN_DIR', 'bin');
+}
+
 class PhpCsFixerHandler extends ToolHandler implements InteractiveToolInterface, PhpCsFixerHandlerInterface
 {
     /** @var array */

--- a/src/PhpGitHooks/Infrastructure/PhpMD/PhpMDHandler.php
+++ b/src/PhpGitHooks/Infrastructure/PhpMD/PhpMDHandler.php
@@ -7,6 +7,10 @@ use PhpGitHooks\Infrastructure\Common\RecursiveToolInterface;
 use PhpGitHooks\Infrastructure\Common\ToolHandler;
 use Symfony\Component\Process\ProcessBuilder;
 
+if (!defined('PHPGITHOOKS_BIN_DIR')) {
+    define('PHPGITHOOKS_BIN_DIR', 'bin');
+}
+
 /**
  * Class PhpMDHandler.
  */

--- a/src/PhpGitHooks/Infrastructure/PhpMD/PhpMDHandler.php
+++ b/src/PhpGitHooks/Infrastructure/PhpMD/PhpMDHandler.php
@@ -35,7 +35,7 @@ class PhpMDHandler extends ToolHandler implements RecursiveToolInterface
             $processBuilder = new ProcessBuilder(
                 array(
                     'php',
-                    'bin/phpmd',
+                    PHPGITHOOKS_BIN_DIR . '/phpmd',
                     $file,
                     'text',
                     'PmdRules.xml',

--- a/src/PhpGitHooks/Infrastructure/PhpUnit/PhpUnitProcessBuilder.php
+++ b/src/PhpGitHooks/Infrastructure/PhpUnit/PhpUnitProcessBuilder.php
@@ -7,6 +7,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\ProcessBuilder;
 
+if (!defined('PHPGITHOOKS_BIN_DIR')) {
+    define('PHPGITHOOKS_BIN_DIR', 'bin');
+}
+
 /**
  * Class PhpUnitProcessBuilder.
  */

--- a/src/PhpGitHooks/Infrastructure/PhpUnit/PhpUnitProcessBuilder.php
+++ b/src/PhpGitHooks/Infrastructure/PhpUnit/PhpUnitProcessBuilder.php
@@ -17,7 +17,7 @@ class PhpUnitProcessBuilder implements ProcessBuilderInterface
      */
     public function getProcessBuilder()
     {
-        return new ProcessBuilder(array('php', 'bin/phpunit'));
+        return new ProcessBuilder(array('php', PHPGITHOOKS_BIN_DIR . '/phpunit'));
     }
 
     /**

--- a/src/PhpGitHooks/Infrastructure/PhpUnit/PhpUnitRandomizerProcessBuilder.php
+++ b/src/PhpGitHooks/Infrastructure/PhpUnit/PhpUnitRandomizerProcessBuilder.php
@@ -4,6 +4,10 @@ namespace PhpGitHooks\Infrastructure\PhpUnit;
 
 use Symfony\Component\Process\ProcessBuilder;
 
+if (!defined('PHPGITHOOKS_BIN_DIR')) {
+    define('PHPGITHOOKS_BIN_DIR', 'bin');
+}
+
 final class PhpUnitRandomizerProcessBuilder extends PhpUnitProcessBuilder
 {
     /**

--- a/src/PhpGitHooks/Infrastructure/PhpUnit/PhpUnitRandomizerProcessBuilder.php
+++ b/src/PhpGitHooks/Infrastructure/PhpUnit/PhpUnitRandomizerProcessBuilder.php
@@ -11,6 +11,6 @@ final class PhpUnitRandomizerProcessBuilder extends PhpUnitProcessBuilder
      */
     public function getProcessBuilder()
     {
-        return new ProcessBuilder(array('php', 'bin/phpunit-randomizer', '--order', 'rand'));
+        return new ProcessBuilder(array('php', PHPGITHOOKS_BIN_DIR . '/phpunit-randomizer', '--order', 'rand'));
     }
 }


### PR DESCRIPTION
If php-git-hooks is installed via `composer global require`, it is
installed in COMPOSER_HOME/vendor directory. So the `autoload.php` path is
different. Besides, bin are installed is COMPOSER_HOME/vendor/bin
directory, that's why I introduced `PHPGITHOOKS_BIN_DIR` constant.