### PR TITLE
Allow to put source files every where

### DIFF
--- a/src/PhpGitHooks/Command/QualityCodeTool.php
+++ b/src/PhpGitHooks/Command/QualityCodeTool.php
@@ -26,8 +26,8 @@ class QualityCodeTool extends Application
     /** @var  OutputHandler */
     private $outputTitleHandler;
 
-    const PHP_FILES_IN_SRC = '/^src\/(.*)(\.php)$/';
-    const JSON_FILES_IN_SRC = '/^src\/(.*)(\.json)$/';
+    const PHP_FILES_IN_SRC = '/^(.*)(\.php)$/';
+    const JSON_FILES_IN_SRC = '/^(.*)(\.json)$/';
     const COMPOSER_FILES = '/^composer\.(json|lock)$/';
 
     public function __construct()


### PR DESCRIPTION
In some repos, sources files can be elsewhere than `src`, even in root dir.