### PR TITLE
Git diff command to track all changes, not only cached!

### DIFF
--- a/src/PhpGitHooks/Infrastructure/Git/ExtractCommitedFiles.php
+++ b/src/PhpGitHooks/Infrastructure/Git/ExtractCommitedFiles.php
@@ -21,7 +21,7 @@ class ExtractCommitedFiles
             $against = 'HEAD';
         }
 
-        exec("git diff-index --cached --name-status $against | egrep '^(A|M)' | awk '{print $2;}'", $this->output);
+        exec("git diff --name-only $against", $this->output);
     }
 
     /**


### PR DESCRIPTION
I am finding this as improvement because otherwise if you do commit -a -m "etc" will not stage the modifications before the hook and will not verify contents of the modified files.