### PR TITLE
Added auto bin dir discovery in cases when we have set config / bin-d…

### DIFF
--- a/src/PhpGitHooks/Application/PhpUnit/PhpUnitHandler.php
+++ b/src/PhpGitHooks/Application/PhpUnit/PhpUnitHandler.php
@@ -15,7 +15,7 @@ use PhpGitHooks\Infrastructure\PhpUnit\PhpUnitProcessBuilder;
 class PhpUnitHandler extends ToolHandler
 {
     /** @var PhpUnitProcessBuilder  */
-    private $phpUnitProcessBuilder;
+    protected $phpUnitProcessBuilder;
 
     /**
      * @param OutputHandlerInterface  $outputHandler
@@ -37,7 +37,7 @@ class PhpUnitHandler extends ToolHandler
     {
         $this->setTitle();
 
-        $processBuilder = $this->phpUnitProcessBuilder->getProcessBuilder();
+        $processBuilder = $this->processBuilder();
         $processBuilder->setTimeout(3600);
         $phpunit = $processBuilder->getProcess();
         $this->phpUnitProcessBuilder
@@ -47,6 +47,14 @@ class PhpUnitHandler extends ToolHandler
             $this->output->writeln(BadJobLogo::paint($messages[MessageConfigData::KEY_ERROR_MESSAGE]));
             throw new UnitTestsException();
         }
+    }
+
+    /**
+     * @return \Symfony\Component\Process\ProcessBuilder
+     */
+    protected function processBuilder()
+    {
+        return $this->phpUnitProcessBuilder->getProcessBuilder($this->getBinPath('phpunit'));
     }
 
     private function setTitle()

--- a/src/PhpGitHooks/Application/PhpUnit/PhpUnitRandomizerHandler.php
+++ b/src/PhpGitHooks/Application/PhpUnit/PhpUnitRandomizerHandler.php
@@ -4,4 +4,11 @@ namespace PhpGitHooks\Application\PhpUnit;
 
 class PhpUnitRandomizerHandler extends PhpUnitHandler
 {
+    /**
+     * @return \Symfony\Component\Process\ProcessBuilder
+     */
+    protected function processBuilder()
+    {
+        return $this->phpUnitProcessBuilder->getProcessBuilder($this->getBinPath('phpunit-randomizer'));
+    }
 }

--- a/src/PhpGitHooks/Infrastructure/CodeSniffer/CodeSnifferHandler.php
+++ b/src/PhpGitHooks/Infrastructure/CodeSniffer/CodeSnifferHandler.php
@@ -54,7 +54,14 @@ class CodeSnifferHandler extends ToolHandler
             }
 
             if (false === $this->ignoreFiles->isIgnored($file)) {
-                $processBuilder = new ProcessBuilder(array('php', 'bin/phpcs', '--standard='.$this->standard, $file));
+                $processBuilder = new ProcessBuilder(
+                    array(
+                        'php',
+                        $this->getBinPath('phpcs'),
+                        '--standard='.$this->standard,
+                        $file,
+                    )
+                );
                 /** @var Process $phpCs */
                 $phpCs = $processBuilder->getProcess();
                 $phpCs->run();

--- a/src/PhpGitHooks/Infrastructure/Common/ProcessBuilderInterface.php
+++ b/src/PhpGitHooks/Infrastructure/Common/ProcessBuilderInterface.php
@@ -12,9 +12,11 @@ use Symfony\Component\Process\ProcessBuilder;
 interface ProcessBuilderInterface
 {
     /**
+     * @param string $bin
+     *
      * @return ProcessBuilder
      */
-    public function getProcessBuilder();
+    public function getProcessBuilder($bin);
 
     /**
      * @param Process         $process

--- a/src/PhpGitHooks/Infrastructure/Common/ToolHandler.php
+++ b/src/PhpGitHooks/Infrastructure/Common/ToolHandler.php
@@ -10,10 +10,25 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 abstract class ToolHandler
 {
+    const COMPOSER_VENDOR_DIR = '/../../../../../../';
+    const COMPOSER_INSTALLED_FILE = 'composer/installed.json';
+
     /** @var OutputHandlerInterface  */
     protected $outputHandler;
     /** @var  OutputInterface */
     protected $output;
+
+    /** @var array */
+    private $tools = array(
+        'phpcs' => 'squizlabs/php_codesniffer',
+        'php-cs-fixer' => 'fabpot/php-cs-fixer',
+        'phpmd' => 'phpmd/phpmd',
+        'phpunit' => 'phpunit/phpunit',
+        'phpunit-randomizer' => 'fiunchinho/phpunit-randomizer',
+        'jsonlint' => 'seld/jsonlint',
+    );
+    /** @var array */
+    private $installedPackages = array();
 
     /**
      * @param OutputHandlerInterface $outputHandler
@@ -21,6 +36,14 @@ abstract class ToolHandler
     public function __construct(OutputHandlerInterface $outputHandler)
     {
         $this->outputHandler = $outputHandler;
+
+        $installedJson = dirname(__FILE__).self::COMPOSER_VENDOR_DIR.self::COMPOSER_INSTALLED_FILE;
+        if (file_exists($installedJson)) { // else not installed over composer
+            $packages = json_decode(file_get_contents($installedJson), true);
+            foreach ($packages as $package) {
+                $this->installedPackages[$package['name']] = $package;
+            }
+        }
     }
 
     /**
@@ -39,5 +62,24 @@ abstract class ToolHandler
     {
         ErrorOutput::write($errorText);
         throw new $exceptionClass();
+    }
+
+    /**
+     * @param string $tool
+     *
+     * @return string
+     */
+    protected function getBinPath($tool)
+    {
+        if (isset($this->installedPackages[$this->tools[$tool]])) {
+            $package = $this->installedPackages[$this->tools[$tool]];
+            foreach ($package['bin'] as $bin) {
+                if (preg_match("#${tool}$#", $bin)) {
+                    return dirname(__FILE__).self::COMPOSER_VENDOR_DIR.$package['name'].DIRECTORY_SEPARATOR.$bin;
+                }
+            }
+        }
+
+        return 'bin'.DIRECTORY_SEPARATOR.$tool;
     }
 }

--- a/src/PhpGitHooks/Infrastructure/JsonLint/JsonLintHandler.php
+++ b/src/PhpGitHooks/Infrastructure/JsonLint/JsonLintHandler.php
@@ -34,7 +34,7 @@ final class JsonLintHandler extends ToolHandler implements RecursiveToolInterfac
             $processBuilder = new ProcessBuilder(
                 array(
                     'php',
-                    'bin/jsonlint',
+                    $this->getBinPath('jsonlint'),
                     $file,
                 )
             );

--- a/src/PhpGitHooks/Infrastructure/PhpCsFixer/PhpCsFixerHandler.php
+++ b/src/PhpGitHooks/Infrastructure/PhpCsFixer/PhpCsFixerHandler.php
@@ -58,7 +58,7 @@ class PhpCsFixerHandler extends ToolHandler implements InteractiveToolInterface,
                         $processBuilder = new ProcessBuilder(
                             array(
                                 'php',
-                                'bin/php-cs-fixer',
+                                $this->getBinPath('php-cs-fixer'),
                                 '--dry-run',
                                 'fix',
                                 $file,

--- a/src/PhpGitHooks/Infrastructure/PhpMD/PhpMDHandler.php
+++ b/src/PhpGitHooks/Infrastructure/PhpMD/PhpMDHandler.php
@@ -56,7 +56,7 @@ class PhpMDHandler extends ToolHandler implements RecursiveToolInterface
                 $processBuilder = new ProcessBuilder(
                     array(
                         'php',
-                        'bin/phpmd',
+                        $this->getBinPath('phpmd'),
                         $file,
                         'text',
                         'PmdRules.xml',

--- a/src/PhpGitHooks/Infrastructure/PhpUnit/PhpUnitProcessBuilder.php
+++ b/src/PhpGitHooks/Infrastructure/PhpUnit/PhpUnitProcessBuilder.php
@@ -13,11 +13,13 @@ use Symfony\Component\Process\ProcessBuilder;
 class PhpUnitProcessBuilder implements ProcessBuilderInterface
 {
     /**
+     * @param string $bin
+     *
      * @return ProcessBuilder
      */
-    public function getProcessBuilder()
+    public function getProcessBuilder($bin)
     {
-        return new ProcessBuilder(array('php', 'bin/phpunit'));
+        return new ProcessBuilder(array('php', $bin));
     }
 
     /**

--- a/src/PhpGitHooks/Infrastructure/PhpUnit/PhpUnitRandomizerProcessBuilder.php
+++ b/src/PhpGitHooks/Infrastructure/PhpUnit/PhpUnitRandomizerProcessBuilder.php
@@ -7,10 +7,12 @@ use Symfony\Component\Process\ProcessBuilder;
 final class PhpUnitRandomizerProcessBuilder extends PhpUnitProcessBuilder
 {
     /**
+     * @param string $bin
+     *
      * @return ProcessBuilder
      */
-    public function getProcessBuilder()
+    public function getProcessBuilder($bin)
     {
-        return new ProcessBuilder(array('php', 'bin/phpunit-randomizer', '--order', 'rand'));
+        return new ProcessBuilder(array('php', $bin, '--order', 'rand'));
     }
 }


### PR DESCRIPTION
I had problems with running all the tools in a specific project setup (we all have some legacy stuff but this specifically do not relate to legacy) where bin-dir was set to a different location which caused problems and inability to for any tool to operate correctly. Thus the changes in this PR are targeted to locating the executables not from the bin dir but from the expected install dirs of the packages. I did not go for the composer.json configuration to checkout where the bin dir is because the vendor-dir configuration could place the package deps anywhere making it impossible to locate the composer.json
Pleasae revise ... sure there could be better ways of doing it.