### PR TITLE
Fix the needle for PHPLint in order to avoid other php.*** endings

### DIFF
--- a/src/PhpGitHooks/Infrastructure/PhpLint/PhpLintHandler.php
+++ b/src/PhpGitHooks/Infrastructure/PhpLint/PhpLintHandler.php
@@ -14,7 +14,7 @@ use Symfony\Component\Process\ProcessBuilder;
  */
 class PhpLintHandler extends ToolHandler implements FilesToolHandlerInterface
 {
-    const NEEDLE = '/(\.php)|(\.inc)$/';
+    const NEEDLE = "/[(\.php)|(\.inc)]$/";
     /** @var array */
     private $files;
 


### PR DESCRIPTION
In order to prevent that other files ending in some kind of "php" text can be analyse.

That happened to me (just put a write to know which is the file where the error is):

Pre-commit tool
Fetching files....................................0k
Running PHPLint...................................
/DevBundle/Controller/VendorController.php
/DevBundle/Resources/views/skeleton/Controller/skeletonController.php.twig

                @@@@@@@@@@@@@@@
             @@@@@@@@@@@@@@@@@@@@
           @@@@@@@@  @@@@@  @@@@@@@
          @@@@@@@@@@  @@@  @@@@@@@@@@
         @@@@@@@@@@@@  @  @@@@@@@@@@@@
        @@@@@@@@@@@  @@@@@  @@@@@@@@@@@
       @@@@@@@@@@@@  @@@@@  @@@@@@@@@@@@
       @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
       @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
        @@@@@@@@@@@@       @@@@@@@@@@@@
         @@@@@@@@@@  @@@@@  @@@@@@@@@@
          @@@@@@@@  @@@@@@@  @@@@@@@@
           @@@@@@@@@@@@@@@@@@@@@@@@@
             @@@@@@@@@@@@@@@@@@@@@
                @@@@@@@@@@@@@@@


           FIX YOUR CODE!!



  [PhpGitHooks\Infrastructure\PhpLint\PhpLintException]
  There are some PHP syntax errors!.
