### PR TITLE
showing MD errors when throws MD exception

### DIFF
--- a/src/PhpGitHooks/Infrastructure/Common/ToolHandler.php
+++ b/src/PhpGitHooks/Infrastructure/Common/ToolHandler.php
@@ -60,7 +60,7 @@ abstract class ToolHandler
      */
     protected function writeOutputError(\Exception $exceptionClass, $errorText)
     {
-        ErrorOutput::write($errorText);
+        $this->output->writeln(ErrorOutput::write($errorText));
         throw new $exceptionClass();
     }
 

--- a/src/PhpGitHooks/Infrastructure/PhpMD/PhpMDHandler.php
+++ b/src/PhpGitHooks/Infrastructure/PhpMD/PhpMDHandler.php
@@ -79,8 +79,8 @@ class PhpMDHandler extends ToolHandler implements RecursiveToolInterface
 
         if (!empty($errors)) {
             $this->writeOutputError(
-                new PHPMDViolationsException(implode('', $errors)),
-                MessageConfigData::KEY_ERROR_MESSAGE
+                new PHPMDViolationsException(MessageConfigData::KEY_ERROR_MESSAGE),
+                implode("\n", $errors)
             );
         }
 


### PR DESCRIPTION
When I receive a message of MD violations it's almost impossible to trace which file is the cause of that exception.

With my modification when the exception is thrown the list of files with violations is printed after the bad face.

So far:

```
Checking code mess with PHPMD.....................

  [PhpGitHooks\Infrastructure\PhpMD\PHPMDViolationsException]
  There are PHPMD violations!
```

With my hack

```
Checking code mess with PHPMD.....................

                @@@@@@@@@@@@@@@
             @@@@@@@@@@@@@@@@@@@@
           @@@@@@@@  @@@@@  @@@@@@@
          @@@@@@@@@@  @@@  @@@@@@@@@@
         @@@@@@@@@@@@  @  @@@@@@@@@@@@
        @@@@@@@@@@@  @@@@@  @@@@@@@@@@@
       @@@@@@@@@@@@  @@@@@  @@@@@@@@@@@@
       @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
       @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
        @@@@@@@@@@@@       @@@@@@@@@@@@
         @@@@@@@@@@  @@@@@  @@@@@@@@@@
          @@@@@@@@  @@@@@@@  @@@@@@@@
           @@@@@@@@@@@@@@@@@@@@@@@@@
             @@@@@@@@@@@@@@@@@@@@@
                @@@@@@@@@@@@@@@

/.../MyClassController.php:246	Avoid unused local variables such as '$myvar'.

  [PhpGitHooks\Infrastructure\PhpMD\PHPMDViolationsException]
  There are PHPMD violations!
```