### PR TITLE
Fix to solve a current error i notize

### DIFF
--- a/src/PhpGitHooks/Infrastructure/PhpMD/PHPMDViolationsException.php
+++ b/src/PhpGitHooks/Infrastructure/PhpMD/PHPMDViolationsException.php
@@ -9,7 +9,7 @@ class PHPMDViolationsException extends \Exception
 {
     protected $message = "There are PHPMD violations!\n";
 
-    public function __construct($message)
+    public function __construct($message = "")
     {
         $this->message .= $message;
     }


### PR DESCRIPTION
Having errors after latest updates, the call made on ToolHandler:64 is breaking the execution.

The original construct of \Exception defines message as optional parameter.