### PR TITLE
Adding more config params to MessDetector

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@ pre-commit:
     phpcs:
         enabled:     true
         standard:    PSR2
-    phpmd:           true
+    phpmd:
+        enabled: true
+        minimum-priority: -1  # -1 => don't apply
     composer:        true
   message:
     right-message: 'HEY, GOOD JOB!!'

--- a/php-git-hooks.yml.sample
+++ b/php-git-hooks.yml.sample
@@ -16,7 +16,9 @@ pre-commit:
     phpcs:
         enabled:    true
         standard:   PSR2
-    phpmd:          true
+    phpmd:
+        enabled:    true
+        minimum-priority: -1  # -1 => don't apply
     composer:       true
   message:
     right-message: 'HEY, GOOD JOB!!'

--- a/src/PhpGitHooks/Application/PhpMD/CheckPhpMessDetectionPreCommitExecutor.php
+++ b/src/PhpGitHooks/Application/PhpMD/CheckPhpMessDetectionPreCommitExecutor.php
@@ -2,6 +2,7 @@
 
 namespace PhpGitHooks\Application\PhpMD;
 
+use PhpGitHooks\Application\Config\HookConfigExtraToolInterface;
 use PhpGitHooks\Application\Config\HookConfigInterface;
 use PhpGitHooks\Infrastructure\Common\PreCommitExecutor;
 use PhpGitHooks\Infrastructure\Common\RecursiveToolInterface;
@@ -18,11 +19,11 @@ class CheckPhpMessDetectionPreCommitExecutor extends PreCommitExecutor
     private $phpMDHandler;
 
     /**
-     * @param HookConfigInterface    $hookConfigInterface
+     * @param HookConfigExtraToolInterface    $hookConfigInterface
      * @param RecursiveToolInterface $recursiveToolInterface
      */
     public function __construct(
-        HookConfigInterface $hookConfigInterface,
+        HookConfigExtraToolInterface $hookConfigInterface,
         RecursiveToolInterface $recursiveToolInterface
     ) {
         $this->phpMDHandler = $recursiveToolInterface;
@@ -46,8 +47,11 @@ class CheckPhpMessDetectionPreCommitExecutor extends PreCommitExecutor
      */
     public function run(OutputInterface $output, array $files, $needle)
     {
-        if ($this->isEnabled()) {
+        $data = $this->preCommitConfig->extraOptions($this->commandName());
+
+        if (true === $data['enabled']) {
             $this->phpMDHandler->setOutput($output);
+            $this->phpMDHandler->setMinimumPriority(isset($data['minimum-priority']) ? intval($data['minimum-priority']) : 1);
             $this->phpMDHandler->setFiles($files);
             $this->phpMDHandler->setNeedle($needle);
             $this->phpMDHandler->run($this->getMessages());

--- a/src/PhpGitHooks/Infrastructure/Common/ToolHandler.php
+++ b/src/PhpGitHooks/Infrastructure/Common/ToolHandler.php
@@ -56,12 +56,13 @@ abstract class ToolHandler
 
     /**
      * @param \Exception $exceptionClass
-     * @param string     $errorText
+     * @param string $errorText
+     * @throws \Exception
      */
     protected function writeOutputError(\Exception $exceptionClass, $errorText)
     {
         $this->output->writeln(ErrorOutput::write($errorText));
-        throw new $exceptionClass();
+        throw $exceptionClass;
     }
 
     /**


### PR DESCRIPTION
Often you going to need to explicitly pass Mess Detector without minimum-priority parameter or with a specific one.
This PR solves that cases.