### PR TITLE
Updated README #48

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If your project doesn't have a "bin/" directory, you can add this in your `compo
 }
 ```
 
-**Note:** This is not necessary for Symfony projects.
+Without this setting Composer would create links to bin files in `vendor/bin`, instead of `bin/`.
 
 ### Manual config file for git hooks.
 


### PR DESCRIPTION
Readme file is misleading.

The bin directory configuration section states that:

> __Note:__ This is not necessary for Symfony projects.

But if omitted, composer would not install bin files to correct directories.
E.g. not in `bin/`, but rather to `vendor/bin/`. Thus `php-git-hooks` is unable to run the bins.

#48 

