### PR TITLE
Php cs fixer add options field

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ pre-commit:
             psr1:       true
             psr2:       true
             symfony:    true
+        options: "--fixers=short_array_syntax --diff"
     phpunit:
         enabled:     true
         random-mode: true

--- a/src/PhpGitHooks/Module/Configuration/Contract/Response/PhpCsFixerResponse.php
+++ b/src/PhpGitHooks/Module/Configuration/Contract/Response/PhpCsFixerResponse.php
@@ -24,6 +24,10 @@ class PhpCsFixerResponse
      * @var bool
      */
     private $phpCsFixerSymfony;
+    /**
+     * @var string|null
+     */
+    private $phpCsFixerOptions;
 
     /**
      * PhpCsFixerResponse constructor.
@@ -33,19 +37,22 @@ class PhpCsFixerResponse
      * @param bool $phpCsFixerPsr1
      * @param bool $phpCsFixerPsr2
      * @param bool $phpCsFixerSymfony
+     * @param string|null $phpCsFixerOptions
      */
     public function __construct(
         $phpCsFixer,
         $phpCsFixerPsr0,
         $phpCsFixerPsr1,
         $phpCsFixerPsr2,
-        $phpCsFixerSymfony
+        $phpCsFixerSymfony,
+        $phpCsFixerOptions
     ) {
         $this->phpCsFixer = $phpCsFixer;
         $this->phpCsFixerPsr0 = $phpCsFixerPsr0;
         $this->phpCsFixerPsr1 = $phpCsFixerPsr1;
         $this->phpCsFixerPsr2 = $phpCsFixerPsr2;
         $this->phpCsFixerSymfony = $phpCsFixerSymfony;
+        $this->phpCsFixerOptions = $phpCsFixerOptions;
     }
 
     /**
@@ -86,5 +93,13 @@ class PhpCsFixerResponse
     public function isPhpCsFixerSymfony()
     {
         return $this->phpCsFixerSymfony;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getPhpCsFixerOptions()
+    {
+        return $this->phpCsFixerOptions;
     }
 }

--- a/src/PhpGitHooks/Module/Configuration/Contract/Response/PhpCsFixerResponse.php
+++ b/src/PhpGitHooks/Module/Configuration/Contract/Response/PhpCsFixerResponse.php
@@ -32,11 +32,11 @@ class PhpCsFixerResponse
     /**
      * PhpCsFixerResponse constructor.
      *
-     * @param bool $phpCsFixer
-     * @param bool $phpCsFixerPsr0
-     * @param bool $phpCsFixerPsr1
-     * @param bool $phpCsFixerPsr2
-     * @param bool $phpCsFixerSymfony
+     * @param bool        $phpCsFixer
+     * @param bool        $phpCsFixerPsr0
+     * @param bool        $phpCsFixerPsr1
+     * @param bool        $phpCsFixerPsr2
+     * @param bool        $phpCsFixerSymfony
      * @param string|null $phpCsFixerOptions
      */
     public function __construct(

--- a/src/PhpGitHooks/Module/Configuration/Domain/PhpCsFixer.php
+++ b/src/PhpGitHooks/Module/Configuration/Domain/PhpCsFixer.php
@@ -18,19 +18,29 @@ class PhpCsFixer implements ToolInterface
      * @var PhpCsFixerLevels
      */
     private $levels;
+    /**
+     * @var PhpCsFixerOptions
+     */
+    private $options;
 
     /**
      * PhpCsFixer constructor.
      *
-     * @param Undefined        $undefined
-     * @param Enabled          $enabled
-     * @param PhpCsFixerLevels $levels
+     * @param Undefined         $undefined
+     * @param Enabled           $enabled
+     * @param PhpCsFixerLevels  $levels
+     * @param PhpCsFixerOptions $options
      */
-    public function __construct(Undefined $undefined, Enabled $enabled, PhpCsFixerLevels $levels)
-    {
+    public function __construct(
+        Undefined $undefined,
+        Enabled $enabled,
+        PhpCsFixerLevels $levels,
+        PhpCsFixerOptions $options
+    ) {
         $this->undefined = $undefined;
         $this->enabled = $enabled;
         $this->levels = $levels;
+        $this->options = $options;
     }
 
     /**
@@ -75,7 +85,8 @@ class PhpCsFixer implements ToolInterface
         return new self(
             new Undefined(false),
             $enabled,
-            $levels
+            $levels,
+            $this->options
         );
     }
 
@@ -89,7 +100,31 @@ class PhpCsFixer implements ToolInterface
         return new self(
             $this->undefined,
             $this->enabled,
-            $levels
+            $levels,
+            $this->options
+        );
+    }
+
+    /**
+     * @return PhpCsFixerOptions
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    /**
+     * @param PhpCsFixerOptions $options
+     *
+     * @return PhpCsFixer
+     */
+    public function setOptions(PhpCsFixerOptions $options)
+    {
+        return new self(
+            $this->undefined,
+            $this->enabled,
+            $this->levels,
+            $options
         );
     }
 }

--- a/src/PhpGitHooks/Module/Configuration/Domain/PhpCsFixerOptions.php
+++ b/src/PhpGitHooks/Module/Configuration/Domain/PhpCsFixerOptions.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace PhpGitHooks\Module\Configuration\Domain;
+
+use PhpValueObjects\NullableInterface;
+use PhpValueObjects\Scalar\StringLiteral;
+
+class PhpCsFixerOptions extends StringLiteral implements NullableInterface
+{
+}

--- a/src/PhpGitHooks/Module/Configuration/Service/ConfigurationArrayTransformer.php
+++ b/src/PhpGitHooks/Module/Configuration/Service/ConfigurationArrayTransformer.php
@@ -71,6 +71,7 @@ class ConfigurationArrayTransformer
                             'psr2' => $phpCsFixer->getLevels()->getPsr2()->value(),
                             'symfony' => $phpCsFixer->getLevels()->getSymfony()->value(),
                         ],
+                        'options' => $phpCsFixer->getOptions()->value(),
                     ],
                     'phpunit' => [
                         'enabled' => $phpunit->isEnabled(),

--- a/src/PhpGitHooks/Module/Configuration/Service/ConfigurationDataResponseFactory.php
+++ b/src/PhpGitHooks/Module/Configuration/Service/ConfigurationDataResponseFactory.php
@@ -101,7 +101,8 @@ class ConfigurationDataResponseFactory
                 $phpCsFixer->getLevels()->getPsr0()->value(),
                 $phpCsFixer->getLevels()->getPsr1()->value(),
                 $phpCsFixer->getLevels()->getPsr2()->value(),
-                $phpCsFixer->getLevels()->getSymfony()->value()
+                $phpCsFixer->getLevels()->getSymfony()->value(),
+                $phpCsFixer->getOptions()->value()
             ),
             new PhpUnitResponse(
                 $phpUnit->isEnabled(),

--- a/src/PhpGitHooks/Module/Configuration/Service/HookQuestions.php
+++ b/src/PhpGitHooks/Module/Configuration/Service/HookQuestions.php
@@ -25,6 +25,7 @@ class HookQuestions
     const PHPCSFIXER_PSR1_LEVEL = '<info>Enable psr1 level for PHP-CS-FIXER?:</info> <comment>[Y/n]</comment>';
     const PHPCSFIXER_PSR2_LEVEL = '<info>Enable psr2 level for PHP-CS-FIXER?:</info> <comment>[Y/n]</comment>';
     const PHPCSFIXER_SYMFONY_LEVEL = '<info>Enable symfony level for PHP-CS-FIXER?:</info> <comment>[Y/n]</comment>';
+    const PHPCSFIXER_OPTIONS = '<info>Write options for PHP-CS-FIXER tool if you want use it:</info> <comment>[NONE]</comment>';
     const PHPUNIT_TOOL = '<info>Do you want enable PHPUNIT tool?:</info> <comment>[Y/n]</comment>';
     const PHPUNIT_RANDOM_MODE = '<info>Do you want run PHPUNIT tool with randomize mode?:</info>'.
     '<comment>[Y/n]</comment>';

--- a/src/PhpGitHooks/Module/Configuration/Service/PhpCsFixerConfigurator.php
+++ b/src/PhpGitHooks/Module/Configuration/Service/PhpCsFixerConfigurator.php
@@ -7,6 +7,7 @@ use PhpGitHooks\Module\Configuration\Domain\Enabled;
 use PhpGitHooks\Module\Configuration\Domain\Level;
 use PhpGitHooks\Module\Configuration\Domain\PhpCsFixer;
 use PhpGitHooks\Module\Configuration\Domain\PhpCsFixerLevels;
+use PhpGitHooks\Module\Configuration\Domain\PhpCsFixerOptions;
 
 class PhpCsFixerConfigurator
 {
@@ -37,6 +38,10 @@ class PhpCsFixerConfigurator
                     new Level(HookQuestions::DEFAULT_TOOL_ANSWER ===  strtoupper($symfonyAnswer))
                 ));
             }
+
+            $optionsAnswer = $io->ask(HookQuestions::PHPCSFIXER_OPTIONS, null);
+            $options = new PhpCsFixerOptions($optionsAnswer);
+            $phpCsFixer = $phpCsFixer->setOptions($options);
         }
 
         return $phpCsFixer;

--- a/src/PhpGitHooks/Module/Configuration/Service/PhpCsFixerFactory.php
+++ b/src/PhpGitHooks/Module/Configuration/Service/PhpCsFixerFactory.php
@@ -4,6 +4,7 @@ namespace PhpGitHooks\Module\Configuration\Service;
 
 use PhpGitHooks\Module\Configuration\Domain\Enabled;
 use PhpGitHooks\Module\Configuration\Domain\PhpCsFixer;
+use PhpGitHooks\Module\Configuration\Domain\PhpCsFixerOptions;
 use PhpGitHooks\Module\Configuration\Domain\Undefined;
 
 class PhpCsFixerFactory
@@ -18,7 +19,8 @@ class PhpCsFixerFactory
         return new PhpCsFixer(
             new Undefined(false),
             new Enabled($data['enabled']),
-            PhpCsFixerLevelsFactory::fromArray($data['levels'])
+            PhpCsFixerLevelsFactory::fromArray($data['levels']),
+            new PhpCsFixerOptions(isset($data['options']) ? $data['options'] : null)
         );
     }
 
@@ -30,7 +32,8 @@ class PhpCsFixerFactory
         return new PhpCsFixer(
             new Undefined(true),
             new Enabled(false),
-            PhpCsFixerLevelsFactory::setUndefined()
+            PhpCsFixerLevelsFactory::setUndefined(),
+            new PhpCsFixerOptions(null)
         );
     }
 }

--- a/src/PhpGitHooks/Module/Configuration/Tests/Behaviour/ConfigurationProcessorCommandHandlerTest.php
+++ b/src/PhpGitHooks/Module/Configuration/Tests/Behaviour/ConfigurationProcessorCommandHandlerTest.php
@@ -89,6 +89,7 @@ final class ConfigurationProcessorCommandHandlerTest extends ConfigurationUnitTe
         $this->shouldAsk(HookQuestions::PHPCSFIXER_PSR1_LEVEL, HookQuestions::DEFAULT_TOOL_ANSWER, $yes);
         $this->shouldAsk(HookQuestions::PHPCSFIXER_PSR2_LEVEL, HookQuestions::DEFAULT_TOOL_ANSWER, $yes);
         $this->shouldAsk(HookQuestions::PHPCSFIXER_SYMFONY_LEVEL, HookQuestions::DEFAULT_TOOL_ANSWER, $yes);
+        $this->shouldAsk(HookQuestions::PHPCSFIXER_OPTIONS, null, ConfigArrayDataStub::PHPCSFIXER_OPTIONS);
         $this->shouldAsk(HookQuestions::PHPUNIT_TOOL, HookQuestions::DEFAULT_TOOL_ANSWER, $yes);
         $this->shouldAsk(HookQuestions::PHPUNIT_RANDOM_MODE, HookQuestions::DEFAULT_TOOL_ANSWER, $yes);
         $this->shouldAsk(HookQuestions::PHPUNIT_OPTIONS, null, ConfigArrayDataStub::PHPUNIT_OPTIONS);

--- a/src/PhpGitHooks/Module/Configuration/Tests/Stub/ConfigArrayDataStub.php
+++ b/src/PhpGitHooks/Module/Configuration/Tests/Stub/ConfigArrayDataStub.php
@@ -12,6 +12,7 @@ class ConfigArrayDataStub
     const REGULAR_EXPRESSION = '#[0-9]{2,7}';
     const ERROR_MESSAGE = 'fix your code';
     const PHPMD_OPTIONS = '--minimumpriority 1';
+    const PHPCSFIXER_OPTIONS = '--diff';
     const MINIMUM_COVERAGE = 90.00;
 
     /**
@@ -42,6 +43,7 @@ class ConfigArrayDataStub
                             'psr2' => true,
                             'symfony' => true,
                         ],
+                        'options' => static::PHPCSFIXER_OPTIONS,
                     ],
                     'phpunit' => [
                         'enabled' => true,

--- a/src/PhpGitHooks/Module/Configuration/Tests/Stub/ConfigurationDataResponseStub.php
+++ b/src/PhpGitHooks/Module/Configuration/Tests/Stub/ConfigurationDataResponseStub.php
@@ -55,7 +55,7 @@ final class ConfigurationDataResponseStub
                 $preCommit,
                 PhpMdResponseStub::create($preCommit, PhpMdResponseStub::OPTIONS),
                 PhpCsResponseStub::create($preCommit, PhpCsResponseStub::STANDARD),
-                PhpCsFixerResponseStub::create($preCommit, $preCommit, $preCommit, $preCommit, $preCommit),
+                PhpCsFixerResponseStub::create($preCommit, $preCommit, $preCommit, $preCommit, $preCommit, PhpCsFixerResponseStub::OPTIONS),
                 PhpUnitResponseStub::create($preCommit, $preCommit, PhpUnitResponseStub::OPTIONS),
                 PhpUnitStrictCoverageResponseStub::create($preCommit, PhpUnitStrictCoverageResponseStub::MINIMUM),
                 PhpUnitGuardCoverageResponseStub::create($preCommit, PhpUnitGuardCoverageResponseStub::WARNING_MESSAGE)

--- a/src/PhpGitHooks/Module/Configuration/Tests/Stub/PhpCsFixerOptionsStub.php
+++ b/src/PhpGitHooks/Module/Configuration/Tests/Stub/PhpCsFixerOptionsStub.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace PhpGitHooks\Module\Configuration\Tests\Stub;
+
+use PhpGitHooks\Module\Configuration\Domain\PhpCsFixerOptions;
+use PhpGitHooks\Module\Tests\Infrastructure\Stub\RandomStubInterface;
+use PhpGitHooks\Module\Tests\Infrastructure\Stub\StubCreator;
+
+class PhpCsFixerOptionsStub implements RandomStubInterface
+{
+    /**
+     * @param string $value
+     *
+     * @return PhpCsFixerOptions
+     */
+    public static function create($value)
+    {
+        return new PhpCsFixerOptions($value);
+    }
+
+    /**
+     * @return PhpCsFixerOptions
+     */
+    public static function random()
+    {
+        return self::create(StubCreator::faker()->word);
+    }
+}

--- a/src/PhpGitHooks/Module/Configuration/Tests/Stub/PhpCsFixerResponseStub.php
+++ b/src/PhpGitHooks/Module/Configuration/Tests/Stub/PhpCsFixerResponseStub.php
@@ -9,11 +9,11 @@ class PhpCsFixerResponseStub
     const OPTIONS = '--diff';
 
     /**
-     * @param bool $phpCsFixer
-     * @param bool $psr0
-     * @param bool $psr1
-     * @param bool $psr2
-     * @param bool $symfony
+     * @param bool        $phpCsFixer
+     * @param bool        $psr0
+     * @param bool        $psr1
+     * @param bool        $psr2
+     * @param bool        $symfony
      * @param string|null $options
      *
      * @return PhpCsFixerResponse

--- a/src/PhpGitHooks/Module/Configuration/Tests/Stub/PhpCsFixerResponseStub.php
+++ b/src/PhpGitHooks/Module/Configuration/Tests/Stub/PhpCsFixerResponseStub.php
@@ -6,18 +6,21 @@ use PhpGitHooks\Module\Configuration\Contract\Response\PhpCsFixerResponse;
 
 class PhpCsFixerResponseStub
 {
+    const OPTIONS = '--diff';
+
     /**
      * @param bool $phpCsFixer
      * @param bool $psr0
      * @param bool $psr1
      * @param bool $psr2
      * @param bool $symfony
+     * @param string|null $options
      *
      * @return PhpCsFixerResponse
      */
-    public static function create($phpCsFixer, $psr0, $psr1, $psr2, $symfony)
+    public static function create($phpCsFixer, $psr0, $psr1, $psr2, $symfony, $options)
     {
-        return new PhpCsFixerResponse($phpCsFixer, $psr0, $psr1, $psr2, $symfony);
+        return new PhpCsFixerResponse($phpCsFixer, $psr0, $psr1, $psr2, $symfony, $options);
     }
 
     /**
@@ -25,6 +28,6 @@ class PhpCsFixerResponseStub
      */
     public static function createEnabled()
     {
-        return self::create(true, true, true, true, true);
+        return self::create(true, true, true, true, true, self::OPTIONS);
     }
 }

--- a/src/PhpGitHooks/Module/Configuration/Tests/Stub/PhpCsFixerStub.php
+++ b/src/PhpGitHooks/Module/Configuration/Tests/Stub/PhpCsFixerStub.php
@@ -5,21 +5,23 @@ namespace PhpGitHooks\Module\Configuration\Tests\Stub;
 use PhpGitHooks\Module\Configuration\Domain\Enabled;
 use PhpGitHooks\Module\Configuration\Domain\PhpCsFixer;
 use PhpGitHooks\Module\Configuration\Domain\PhpCsFixerLevels;
+use PhpGitHooks\Module\Configuration\Domain\PhpCsFixerOptions;
 use PhpGitHooks\Module\Configuration\Domain\Undefined;
 use PhpGitHooks\Module\Tests\Infrastructure\Stub\RandomStubInterface;
 
 class PhpCsFixerStub implements RandomStubInterface
 {
     /**
-     * @param Undefined        $undefined
-     * @param Enabled          $enabled
-     * @param PhpCsFixerLevels $levels
+     * @param Undefined         $undefined
+     * @param Enabled           $enabled
+     * @param PhpCsFixerLevels  $levels
+     * @param PhpCsFixerOptions $options
      *
      * @return PhpCsFixer
      */
-    public static function create(Undefined $undefined, Enabled $enabled, PhpCsFixerLevels $levels)
+    public static function create(Undefined $undefined, Enabled $enabled, PhpCsFixerLevels $levels, PhpCsFixerOptions $options)
     {
-        return new PhpCsFixer($undefined, $enabled, $levels);
+        return new PhpCsFixer($undefined, $enabled, $levels, $options);
     }
 
     /**
@@ -27,7 +29,7 @@ class PhpCsFixerStub implements RandomStubInterface
      */
     public static function random()
     {
-        return self::create(new Undefined(false), EnabledStub::random(), PhpCsFixerLevelsStub::random());
+        return self::create(new Undefined(false), EnabledStub::random(), PhpCsFixerLevelsStub::random(), PhpCsFixerOptionsStub::random());
     }
 
     /**
@@ -35,6 +37,6 @@ class PhpCsFixerStub implements RandomStubInterface
      */
     public static function createEnabled()
     {
-        return self::create(new Undefined(false), EnabledStub::create(true), PhpCsFixerLevelsStub::createEnabled());
+        return self::create(new Undefined(false), EnabledStub::create(true), PhpCsFixerLevelsStub::createEnabled(), PhpCsFixerOptionsStub::create(null));
     }
 }

--- a/src/PhpGitHooks/Module/Git/Service/PreCommitTool.php
+++ b/src/PhpGitHooks/Module/Git/Service/PreCommitTool.php
@@ -143,6 +143,7 @@ class PreCommitTool
                         $phpCsFixerResponse->isPhpCsFixerPsr1(),
                         $phpCsFixerResponse->isPhpCsFixerPsr2(),
                         $phpCsFixerResponse->isPhpCsFixerSymfony(),
+                        $phpCsFixerResponse->getPhpCsFixerOptions(),
                         $preCommitResponse->getErrorMessage()
                     )
                 );

--- a/src/PhpGitHooks/Module/Git/Tests/Behaviour/PreCommitToolCommandHandlerTest.php
+++ b/src/PhpGitHooks/Module/Git/Tests/Behaviour/PreCommitToolCommandHandlerTest.php
@@ -94,6 +94,7 @@ class PreCommitToolCommandHandlerTest extends GitUnitTestCase
                 $configurationDataResponse->getPreCommit()->getPhpCsFixer()->isPhpCsFixerPsr1(),
                 $configurationDataResponse->getPreCommit()->getPhpCsFixer()->isPhpCsFixerPsr2(),
                 $configurationDataResponse->getPreCommit()->getPhpCsFixer()->isPhpCsFixerSymfony(),
+                $configurationDataResponse->getPreCommit()->getPhpCsFixer()->getPhpCsFixerOptions(),
                 $configurationDataResponse->getPreCommit()->getErrorMessage()
             )
         );

--- a/src/PhpGitHooks/Module/PhpCsFixer/Contract/Command/PhpCsFixerToolCommand.php
+++ b/src/PhpGitHooks/Module/PhpCsFixer/Contract/Command/PhpCsFixerToolCommand.php
@@ -29,6 +29,10 @@ class PhpCsFixerToolCommand implements CommandInterface
     /**
      * @var string
      */
+    private $options;
+    /**
+     * @var string
+     */
     private $errorMessage;
 
     /**
@@ -39,15 +43,17 @@ class PhpCsFixerToolCommand implements CommandInterface
      * @param bool   $psr1
      * @param bool   $psr2
      * @param bool   $symfony
+     * @param string $options
      * @param string $errorMessage
      */
-    public function __construct(array $files, $psr0, $psr1, $psr2, $symfony, $errorMessage)
+    public function __construct(array $files, $psr0, $psr1, $psr2, $symfony, $options, $errorMessage)
     {
         $this->files = $files;
         $this->psr0 = $psr0;
         $this->psr1 = $psr1;
         $this->psr2 = $psr2;
         $this->symfony = $symfony;
+        $this->options = $options;
         $this->errorMessage = $errorMessage;
     }
 
@@ -89,6 +95,14 @@ class PhpCsFixerToolCommand implements CommandInterface
     public function isSymfony()
     {
         return $this->symfony;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOptions()
+    {
+        return $this->options;
     }
 
     /**

--- a/src/PhpGitHooks/Module/PhpCsFixer/Contract/CommandHandler/PhpCsFixerToolCommandHandler.php
+++ b/src/PhpGitHooks/Module/PhpCsFixer/Contract/CommandHandler/PhpCsFixerToolCommandHandler.php
@@ -35,6 +35,7 @@ class PhpCsFixerToolCommandHandler implements CommandHandlerInterface
             $command->isPsr1(),
             $command->isPsr2(),
             $command->isSymfony(),
+            $command->getOptions(),
             $command->getErrorMessage()
         );
     }

--- a/src/PhpGitHooks/Module/PhpCsFixer/Infrastructure/Tool/PhpCsFixerToolProcessor.php
+++ b/src/PhpGitHooks/Module/PhpCsFixer/Infrastructure/Tool/PhpCsFixerToolProcessor.php
@@ -27,12 +27,13 @@ class PhpCsFixerToolProcessor implements PhpCsFixerToolProcessorInterface
     /**
      * @param string $file
      * @param string $level
+     * @param string $options
      *
      * @return string
      */
-    public function process($file, $level)
+    public function process($file, $level, $options)
     {
-        $process = $this->processTool($file, $level);
+        $process = $this->processTool($file, $level, $options);
 
         return $this->setError($process);
     }
@@ -40,21 +41,26 @@ class PhpCsFixerToolProcessor implements PhpCsFixerToolProcessorInterface
     /**
      * @param string $file
      * @param string $level
+     * @param string $options
      *
      * @return Process
      */
-    private function processTool($file, $level)
+    private function processTool($file, $level, $options)
     {
-        $processBuilder = new ProcessBuilder(
-            [
-                'php',
-                $this->toolPathFinder->find('php-cs-fixer'),
-                '--dry-run',
-                'fix',
-                $file,
-                '--level='.$level,
-            ]
-        );
+        $arguments = [
+            'php',
+            $this->toolPathFinder->find('php-cs-fixer'),
+            '--dry-run',
+            'fix',
+            $file,
+            '--level='.$level,
+        ];
+
+        if (null !== $options) {
+            $arguments = array_merge($arguments, explode(' ', trim($options)));
+        }
+
+        $processBuilder = new ProcessBuilder($arguments);
 
         $process = $processBuilder->getProcess();
         $process->run();

--- a/src/PhpGitHooks/Module/PhpCsFixer/Model/PhpCsFixerToolProcessorInterface.php
+++ b/src/PhpGitHooks/Module/PhpCsFixer/Model/PhpCsFixerToolProcessorInterface.php
@@ -7,8 +7,9 @@ interface PhpCsFixerToolProcessorInterface
     /**
      * @param string $file
      * @param string $level
+     * @param string $options
      *
      * @return string
      */
-    public function process($file, $level);
+    public function process($file, $level, $options);
 }

--- a/src/PhpGitHooks/Module/PhpCsFixer/Service/PhpCsFixerTool.php
+++ b/src/PhpGitHooks/Module/PhpCsFixer/Service/PhpCsFixerTool.php
@@ -37,42 +37,44 @@ class PhpCsFixerTool
      * @param bool   $psr1
      * @param bool   $psr2
      * @param bool   $symfony
+     * @param string $options
      * @param string $errorMessage
      */
-    public function execute(array $files, $psr0, $psr1, $psr2, $symfony, $errorMessage)
+    public function execute(array $files, $psr0, $psr1, $psr2, $symfony, $options, $errorMessage)
     {
         if (true === $psr0) {
-            $this->executeTool($files, 'PSR0', $errorMessage);
+            $this->executeTool($files, 'PSR0', $options, $errorMessage);
         }
 
         if (true === $psr1) {
-            $this->executeTool($files, 'PSR1', $errorMessage);
+            $this->executeTool($files, 'PSR1', $options, $errorMessage);
         }
 
         if (true === $psr2) {
-            $this->executeTool($files, 'PSR2', $errorMessage);
+            $this->executeTool($files, 'PSR2', $options, $errorMessage);
         }
 
         if (true === $symfony) {
-            $this->executeTool($files, 'SYMFONY', $errorMessage);
+            $this->executeTool($files, 'SYMFONY', $options, $errorMessage);
         }
     }
 
     /**
      * @param array  $files
      * @param string $level
+     * @param string $options
      * @param string $errorMessage
      *
      * @throws PhpCsFixerViolationsException
      */
-    private function executeTool(array $files, $level, $errorMessage)
+    private function executeTool(array $files, $level, $options, $errorMessage)
     {
         $outputMessage = new PreCommitOutputWriter(sprintf('Checking %s code style with PHP-CS-FIXER', $level));
         $this->output->write($outputMessage->getMessage());
 
         $errors = [];
         foreach ($files as $file) {
-            $errors[] = $this->phpCsFixerToolProcessor->process($file, $level);
+            $errors[] = $this->phpCsFixerToolProcessor->process($file, $level, $options);
         }
 
         $errors = array_filter($errors);

--- a/src/PhpGitHooks/Module/PhpCsFixer/Tests/Behaviour/PhpCsFixerToolCommandHandlerTest.php
+++ b/src/PhpGitHooks/Module/PhpCsFixer/Tests/Behaviour/PhpCsFixerToolCommandHandlerTest.php
@@ -3,6 +3,7 @@
 namespace PhpGitHooks\Module\PhpCsFixer\Tests\Behaviour;
 
 use PhpGitHooks\Module\Configuration\Tests\Stub\ConfigurationDataResponseStub;
+use PhpGitHooks\Module\Configuration\Tests\Stub\PhpCsFixerOptionsStub;
 use PhpGitHooks\Module\Git\Contract\Response\BadJobLogoResponse;
 use PhpGitHooks\Module\Git\Service\PreCommitOutputWriter;
 use PhpGitHooks\Module\Git\Tests\Stub\FilesCommittedStub;
@@ -36,6 +37,7 @@ class PhpCsFixerToolCommandHandlerTest extends PhpCsFixerUnitTestCase
     {
         $this->expectException(PhpCsFixerViolationsException::class);
 
+        $phpCsFixerOptions = PhpCsFixerOptionsStub::random();
         $configurationData = ConfigurationDataResponseStub::createAllEnabled();
         $phpFiles = FilesCommittedStub::createOnlyPhpFiles();
 
@@ -45,7 +47,7 @@ class PhpCsFixerToolCommandHandlerTest extends PhpCsFixerUnitTestCase
         $errors = null;
         foreach ($phpFiles as $file) {
             $errorText = 'ERROR';
-            $this->shouldProcessPhpCsFixerTool($file, 'PSR0', $errorText);
+            $this->shouldProcessPhpCsFixerTool($file, 'PSR0', $phpCsFixerOptions->value(), $errorText);
             $errors .= $errorText;
         }
 
@@ -60,6 +62,7 @@ class PhpCsFixerToolCommandHandlerTest extends PhpCsFixerUnitTestCase
                 $configurationData->getPreCommit()->getPhpCsFixer()->isPhpCsFixerPsr1(),
                 $configurationData->getPreCommit()->getPhpCsFixer()->isPhpCsFixerPsr2(),
                 $configurationData->getPreCommit()->getPhpCsFixer()->isPhpCsFixerSymfony(),
+                $phpCsFixerOptions->value(),
                 $configurationData->getPreCommit()->getErrorMessage()
             )
         );
@@ -70,6 +73,7 @@ class PhpCsFixerToolCommandHandlerTest extends PhpCsFixerUnitTestCase
      */
     public function itShouldWorksFine()
     {
+        $phpCsFixerOptions = PhpCsFixerOptionsStub::random();
         $configurationData = ConfigurationDataResponseStub::createAllEnabled();
         $phpFiles = FilesCommittedStub::createOnlyPhpFiles();
 
@@ -77,7 +81,7 @@ class PhpCsFixerToolCommandHandlerTest extends PhpCsFixerUnitTestCase
         $this->shouldWriteOutput($outputMessagePsr0->getMessage());
 
         foreach ($phpFiles as $file) {
-            $this->shouldProcessPhpCsFixerTool($file, 'PSR0', null);
+            $this->shouldProcessPhpCsFixerTool($file, 'PSR0', $phpCsFixerOptions->value(), null);
         }
 
         $this->shouldWriteLnOutput($outputMessagePsr0->getSuccessfulMessage());
@@ -86,7 +90,7 @@ class PhpCsFixerToolCommandHandlerTest extends PhpCsFixerUnitTestCase
         $this->shouldWriteOutput($outputMessagePsr1->getMessage());
 
         foreach ($phpFiles as $file) {
-            $this->shouldProcessPhpCsFixerTool($file, 'PSR1', null);
+            $this->shouldProcessPhpCsFixerTool($file, 'PSR1', $phpCsFixerOptions->value(), null);
         }
 
         $this->shouldWriteLnOutput($outputMessagePsr1->getSuccessfulMessage());
@@ -95,7 +99,7 @@ class PhpCsFixerToolCommandHandlerTest extends PhpCsFixerUnitTestCase
         $this->shouldWriteOutput($outputMessagePsr2->getMessage());
 
         foreach ($phpFiles as $file) {
-            $this->shouldProcessPhpCsFixerTool($file, 'PSR2', null);
+            $this->shouldProcessPhpCsFixerTool($file, 'PSR2', $phpCsFixerOptions->value(), null);
         }
 
         $this->shouldWriteLnOutput($outputMessagePsr2->getSuccessfulMessage());
@@ -104,7 +108,7 @@ class PhpCsFixerToolCommandHandlerTest extends PhpCsFixerUnitTestCase
         $this->shouldWriteOutput($outputMessageSymfony->getMessage());
 
         foreach ($phpFiles as $file) {
-            $this->shouldProcessPhpCsFixerTool($file, 'SYMFONY', null);
+            $this->shouldProcessPhpCsFixerTool($file, 'SYMFONY', $phpCsFixerOptions->value(), null);
         }
 
         $this->shouldWriteLnOutput($outputMessageSymfony->getSuccessfulMessage());
@@ -116,6 +120,7 @@ class PhpCsFixerToolCommandHandlerTest extends PhpCsFixerUnitTestCase
                 $configurationData->getPreCommit()->getPhpCsFixer()->isPhpCsFixerPsr1(),
                 $configurationData->getPreCommit()->getPhpCsFixer()->isPhpCsFixerPsr2(),
                 $configurationData->getPreCommit()->getPhpCsFixer()->isPhpCsFixerSymfony(),
+                $phpCsFixerOptions->value(),
                 $configurationData->getPreCommit()->getErrorMessage()
             )
         );

--- a/src/PhpGitHooks/Module/PhpCsFixer/Tests/Infrastructure/PhpCsFixerToolProcessorTrait.php
+++ b/src/PhpGitHooks/Module/PhpCsFixer/Tests/Infrastructure/PhpCsFixerToolProcessorTrait.php
@@ -27,14 +27,15 @@ trait PhpCsFixerToolProcessorTrait
     /**
      * @param string $file
      * @param string $level
+     * @param string $options
      * @param string $return
      */
-    protected function shouldProcessPhpCsFixerTool($file, $level, $return)
+    protected function shouldProcessPhpCsFixerTool($file, $level, $options, $return)
     {
         $this->getPhpCsFixerToolProcessor()
             ->shouldReceive('process')
             ->once()
-            ->withArgs([$file, $level])
+            ->withArgs([$file, $level, $options])
             ->andReturn($return);
     }
 }


### PR DESCRIPTION
Hello,

At Ironweb, we use the php-git-hooks tool to have pre-commit hook with php-cs-fixer.
We wanted to add some options on the command php-cs-fixer like "--fixers=short_array_syntax --diff --verbose".

To do so, we added an options field for php-cs-fixer.
The options have to be filled in the php-git-hooks.yml as mentioned in the updated documentation. Otherwise it is not a mandatory field.

We have also updated the tests accordingly.

Thanks in advance for your returns