### PR TITLE
Create .git/hooks dir if it doesnt exist

### DIFF
--- a/src/PhpGitHooks/Module/Configuration/Infrastructure/Hook/HookCopier.php
+++ b/src/PhpGitHooks/Module/Configuration/Infrastructure/Hook/HookCopier.php
@@ -38,7 +38,7 @@ class HookCopier
      */
     private function copyFile($hookFile)
     {
-        $copy = new Process(sprintf('cp %s %s', $hookFile, $this->hookDir));
+        $copy = new Process(sprintf("mkdir -p {$this->hookDir} && cp %s %s", $hookFile, $this->hookDir));
         $copy->run();
     }
 


### PR DESCRIPTION
Before this PR the hooks were not installed (silently, no warning is given to the user) if the `.git/hooks` directory does not exist.