### PR TITLE
Implement support for PHP CS ignore option

### DIFF
--- a/php-git-hooks.yml.sample
+++ b/php-git-hooks.yml.sample
@@ -23,6 +23,7 @@ pre-commit:
     phpcs:
         enabled:     true
         standard:    PSR2
+        ignore:      '*/migrations/*'
     phpmd:
         enabled:     true
         options:     '<some options>'

--- a/src/PhpGitHooks/Module/Configuration/Contract/Response/PhpCsResponse.php
+++ b/src/PhpGitHooks/Module/Configuration/Contract/Response/PhpCsResponse.php
@@ -12,6 +12,10 @@ class PhpCsResponse
      * @var null|string
      */
     private $phpCsStandard;
+    /**
+     * @var string
+     */
+    private $ignore;
 
     /**
      * PhpCsResponse constructor.
@@ -19,10 +23,11 @@ class PhpCsResponse
      * @param bool        $phpCs
      * @param string|null $phpCsStandard
      */
-    public function __construct($phpCs, $phpCsStandard)
+    public function __construct($phpCs, $phpCsStandard, $ignore)
     {
         $this->phpCs = $phpCs;
         $this->phpCsStandard = $phpCsStandard;
+        $this->ignore = $ignore;
     }
 
     /**
@@ -39,5 +44,10 @@ class PhpCsResponse
     public function getPhpCsStandard()
     {
         return $this->phpCsStandard;
+    }
+
+    public function getIgnore()
+    {
+        return $this->ignore;
     }
 }

--- a/src/PhpGitHooks/Module/Configuration/Contract/Response/PhpCsResponse.php
+++ b/src/PhpGitHooks/Module/Configuration/Contract/Response/PhpCsResponse.php
@@ -22,6 +22,7 @@ class PhpCsResponse
      *
      * @param bool        $phpCs
      * @param string|null $phpCsStandard
+     * @param string      $ignore
      */
     public function __construct($phpCs, $phpCsStandard, $ignore)
     {
@@ -46,6 +47,9 @@ class PhpCsResponse
         return $this->phpCsStandard;
     }
 
+    /**
+     * @return string
+     */
     public function getIgnore()
     {
         return $this->ignore;

--- a/src/PhpGitHooks/Module/Configuration/Domain/Ignore.php
+++ b/src/PhpGitHooks/Module/Configuration/Domain/Ignore.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace PhpGitHooks\Module\Configuration\Domain;
+
+use PhpValueObjects\Tests\Scalar\StringValueObject;
+
+class Ignore extends StringValueObject
+{
+}

--- a/src/PhpGitHooks/Module/Configuration/Domain/Ignore.php
+++ b/src/PhpGitHooks/Module/Configuration/Domain/Ignore.php
@@ -2,8 +2,8 @@
 
 namespace PhpGitHooks\Module\Configuration\Domain;
 
-use PhpValueObjects\Tests\Scalar\StringValueObject;
+use PhpValueObjects\Tests\Scalar\StringNullableValueObject;
 
-class Ignore extends StringValueObject
+class Ignore extends StringNullableValueObject
 {
 }

--- a/src/PhpGitHooks/Module/Configuration/Domain/PhpCs.php
+++ b/src/PhpGitHooks/Module/Configuration/Domain/PhpCs.php
@@ -63,6 +63,9 @@ class PhpCs implements ToolInterface
         return $this->standard;
     }
 
+    /**
+     * @return Ignore
+     */
     public function getIgnore()
     {
         return $this->ignore;

--- a/src/PhpGitHooks/Module/Configuration/Domain/PhpCs.php
+++ b/src/PhpGitHooks/Module/Configuration/Domain/PhpCs.php
@@ -18,6 +18,10 @@ class PhpCs implements ToolInterface
      * @var PhpCsStandard
      */
     private $standard;
+    /**
+     * @var Ignore
+     */
+    private $ignore;
 
     /**
      * PhpCs constructor.
@@ -25,12 +29,14 @@ class PhpCs implements ToolInterface
      * @param Undefined     $undefined
      * @param Enabled       $enabled
      * @param PhpCsStandard $standard
+     * @param Ignore        $ignore
      */
-    public function __construct(Undefined $undefined, Enabled $enabled, PhpCsStandard $standard)
+    public function __construct(Undefined $undefined, Enabled $enabled, PhpCsStandard $standard, Ignore $ignore)
     {
         $this->undefined = $undefined;
         $this->enabled = $enabled;
         $this->standard = $standard;
+        $this->ignore = $ignore;
     }
 
     /**
@@ -57,6 +63,11 @@ class PhpCs implements ToolInterface
         return $this->standard;
     }
 
+    public function getIgnore()
+    {
+        return $this->ignore;
+    }
+
     /**
      * @return ToolInterface
      */
@@ -65,7 +76,8 @@ class PhpCs implements ToolInterface
         return new self(
             new Undefined(false),
             $enabled,
-            new PhpCsStandard(null)
+            new PhpCsStandard(null),
+            new Ignore(null)
         );
     }
 
@@ -79,7 +91,8 @@ class PhpCs implements ToolInterface
         return new self(
             $this->undefined,
             $this->enabled,
-            $standard
+            $standard,
+            $this->ignore
         );
     }
 }

--- a/src/PhpGitHooks/Module/Configuration/Domain/PhpCs.php
+++ b/src/PhpGitHooks/Module/Configuration/Domain/PhpCs.php
@@ -80,7 +80,7 @@ class PhpCs implements ToolInterface
             new Undefined(false),
             $enabled,
             new PhpCsStandard(null),
-            new Ignore(null)
+            new Ignore('')
         );
     }
 

--- a/src/PhpGitHooks/Module/Configuration/Domain/PhpCs.php
+++ b/src/PhpGitHooks/Module/Configuration/Domain/PhpCs.php
@@ -80,7 +80,7 @@ class PhpCs implements ToolInterface
             new Undefined(false),
             $enabled,
             new PhpCsStandard(null),
-            new Ignore('')
+            new Ignore(null)
         );
     }
 
@@ -97,5 +97,13 @@ class PhpCs implements ToolInterface
             $standard,
             $this->ignore
         );
+    }
+
+    /**
+     * @param Ignore $ignore
+     */
+    public function addIgnore(Ignore $ignore)
+    {
+        $this->ignore = $ignore;
     }
 }

--- a/src/PhpGitHooks/Module/Configuration/Service/ConfigurationArrayTransformer.php
+++ b/src/PhpGitHooks/Module/Configuration/Service/ConfigurationArrayTransformer.php
@@ -62,6 +62,7 @@ class ConfigurationArrayTransformer
                     'phpcs' => [
                         'enabled' => $phpCs->isEnabled(),
                         'standard' => $phpCs->getStandard()->value(),
+                        'ignore' => $phpCs->getIgnore()->value(),
                     ],
                     'php-cs-fixer' => [
                         'enabled' => $phpCsFixer->isEnabled(),

--- a/src/PhpGitHooks/Module/Configuration/Service/ConfigurationDataResponseFactory.php
+++ b/src/PhpGitHooks/Module/Configuration/Service/ConfigurationDataResponseFactory.php
@@ -95,7 +95,7 @@ class ConfigurationDataResponseFactory
             $jsonLint->isEnabled(),
             $phpLint->isEnabled(),
             new PhpMdResponse($phpMd->isEnabled(), $phpMd->getOptions()->value()),
-            new PhpCsResponse($phpCs->isEnabled(), $phpCs->getStandard()->value()),
+            new PhpCsResponse($phpCs->isEnabled(), $phpCs->getStandard()->value(), $phpCs->getIgnore()->value()),
             new PhpCsFixerResponse(
                 $phpCsFixer->isEnabled(),
                 $phpCsFixer->getLevels()->getPsr0()->value(),

--- a/src/PhpGitHooks/Module/Configuration/Service/HookQuestions.php
+++ b/src/PhpGitHooks/Module/Configuration/Service/HookQuestions.php
@@ -18,6 +18,8 @@ class HookQuestions
     const PHPCS_TOOL = '<info>Do you want enable PHPCS tool?:</info> <comment>[Y/n]</comment>';
     const PHPCS_STANDARD = '<info>Which standard do you want to user for PHPCS tool?:</info> '.
     '<comment>[PSR1/PSR2/PHPCS/MySource/Zend/Squiz/PEAR]</comment>';
+    const PHPCS_IGNORE = '<info>Write ignore pattern for PHPCS, if you like:</info> '.
+    '<comment>[No ignore pattern]</comment>';
     const PHPMD_TOOL = '<info>Do you want enable PHPMD tool?:</info> <comment>[Y/n]</comment>';
     const PHPMD_OPTIONS = '<info>Write options for PHPMD tool if you want use it:</info> <comment>[NONE]</comment>';
     const PHPCSFIXER_TOOL = '<info>Do you want enable PHP-CS-FIXER tool?:</info> <comment>[Y/n]</comment>';

--- a/src/PhpGitHooks/Module/Configuration/Service/PhpCsConfigurator.php
+++ b/src/PhpGitHooks/Module/Configuration/Service/PhpCsConfigurator.php
@@ -4,6 +4,7 @@ namespace PhpGitHooks\Module\Configuration\Service;
 
 use Composer\IO\IOInterface;
 use PhpGitHooks\Module\Configuration\Domain\Enabled;
+use PhpGitHooks\Module\Configuration\Domain\Ignore;
 use PhpGitHooks\Module\Configuration\Domain\PhpCs;
 use PhpGitHooks\Module\Configuration\Domain\PhpCsStandard;
 
@@ -25,6 +26,9 @@ class PhpCsConfigurator
                 $standardAnswer = $io->ask(HookQuestions::PHPCS_STANDARD, null);
                 /** @var PhpCs $phpCs */
                 $phpCs = $phpCs->addStandard(new PhpCsStandard($standardAnswer));
+
+                $ignoreOptionAnswer = $io->ask(HookQuestions::PHPCS_IGNORE, null);
+                $phpCs->addIgnore(new Ignore($ignoreOptionAnswer));
             }
         }
 

--- a/src/PhpGitHooks/Module/Configuration/Service/PhpCsFactory.php
+++ b/src/PhpGitHooks/Module/Configuration/Service/PhpCsFactory.php
@@ -34,7 +34,7 @@ class PhpCsFactory
             new Undefined(true),
             new Enabled(false),
             new PhpCsStandard(null),
-            new Ignore(null)
+            new Ignore('')
         );
     }
 }

--- a/src/PhpGitHooks/Module/Configuration/Service/PhpCsFactory.php
+++ b/src/PhpGitHooks/Module/Configuration/Service/PhpCsFactory.php
@@ -3,6 +3,7 @@
 namespace PhpGitHooks\Module\Configuration\Service;
 
 use PhpGitHooks\Module\Configuration\Domain\Enabled;
+use PhpGitHooks\Module\Configuration\Domain\Ignore;
 use PhpGitHooks\Module\Configuration\Domain\PhpCs;
 use PhpGitHooks\Module\Configuration\Domain\PhpCsStandard;
 use PhpGitHooks\Module\Configuration\Domain\Undefined;
@@ -19,7 +20,8 @@ class PhpCsFactory
         return new PhpCs(
             new Undefined(false),
             new Enabled($data['enabled']),
-            new PhpCsStandard($data['standard'])
+            new PhpCsStandard($data['standard']),
+            new Ignore(isset($data['ignore']) ? $data['ignore'] : '')
         );
     }
 
@@ -31,7 +33,8 @@ class PhpCsFactory
         return new PhpCs(
             new Undefined(true),
             new Enabled(false),
-            new PhpCsStandard(null)
+            new PhpCsStandard(null),
+            new Ignore(null)
         );
     }
 }

--- a/src/PhpGitHooks/Module/Configuration/Tests/Behaviour/ConfigurationProcessorCommandHandlerTest.php
+++ b/src/PhpGitHooks/Module/Configuration/Tests/Behaviour/ConfigurationProcessorCommandHandlerTest.php
@@ -84,6 +84,7 @@ final class ConfigurationProcessorCommandHandlerTest extends ConfigurationUnitTe
         $this->shouldAsk(HookQuestions::PHPMD_OPTIONS, null, ConfigArrayDataStub::PHPMD_OPTIONS);
         $this->shouldAsk(HookQuestions::PHPCS_TOOL, HookQuestions::DEFAULT_TOOL_ANSWER, $yes);
         $this->shouldAsk(HookQuestions::PHPCS_STANDARD, null, ConfigArrayDataStub::PHPCS_STANDARD);
+        $this->shouldAsk(HookQuestions::PHPCS_IGNORE, null, ConfigArrayDataStub::EMPTY_STRING);
         $this->shouldAsk(HookQuestions::PHPCSFIXER_TOOL, HookQuestions::DEFAULT_TOOL_ANSWER, $yes);
         $this->shouldAsk(HookQuestions::PHPCSFIXER_PSR0_LEVEL, HookQuestions::DEFAULT_TOOL_ANSWER, $yes);
         $this->shouldAsk(HookQuestions::PHPCSFIXER_PSR1_LEVEL, HookQuestions::DEFAULT_TOOL_ANSWER, $yes);

--- a/src/PhpGitHooks/Module/Configuration/Tests/Stub/ConfigArrayDataStub.php
+++ b/src/PhpGitHooks/Module/Configuration/Tests/Stub/ConfigArrayDataStub.php
@@ -14,6 +14,7 @@ class ConfigArrayDataStub
     const PHPMD_OPTIONS = '--minimumpriority 1';
     const PHPCSFIXER_OPTIONS = '--diff';
     const MINIMUM_COVERAGE = 90.00;
+    const EMPTY_STRING = '';
 
     /**
      * @return array
@@ -34,6 +35,7 @@ class ConfigArrayDataStub
                     'phpcs' => [
                         'enabled' => true,
                         'standard' => static::PHPCS_STANDARD,
+                        'ignore' => static::EMPTY_STRING,
                     ],
                     'php-cs-fixer' => [
                         'enabled' => true,

--- a/src/PhpGitHooks/Module/Configuration/Tests/Stub/ConfigurationDataResponseStub.php
+++ b/src/PhpGitHooks/Module/Configuration/Tests/Stub/ConfigurationDataResponseStub.php
@@ -54,7 +54,7 @@ final class ConfigurationDataResponseStub
                 $preCommit,
                 $preCommit,
                 PhpMdResponseStub::create($preCommit, PhpMdResponseStub::OPTIONS),
-                PhpCsResponseStub::create($preCommit, PhpCsResponseStub::STANDARD),
+                PhpCsResponseStub::create($preCommit, PhpCsResponseStub::STANDARD, PhpCsResponseStub::IGNORE),
                 PhpCsFixerResponseStub::create($preCommit, $preCommit, $preCommit, $preCommit, $preCommit, PhpCsFixerResponseStub::OPTIONS),
                 PhpUnitResponseStub::create($preCommit, $preCommit, PhpUnitResponseStub::OPTIONS),
                 PhpUnitStrictCoverageResponseStub::create($preCommit, PhpUnitStrictCoverageResponseStub::MINIMUM),

--- a/src/PhpGitHooks/Module/Configuration/Tests/Stub/IgnoreStub.php
+++ b/src/PhpGitHooks/Module/Configuration/Tests/Stub/IgnoreStub.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace PhpGitHooks\Module\Configuration\Tests\Stub;
+
+use PhpGitHooks\Module\Configuration\Domain\Ignore;
+use PhpGitHooks\Module\Tests\Infrastructure\Stub\RandomStubInterface;
+use PhpGitHooks\Module\Tests\Infrastructure\Stub\StubCreator;
+
+class IgnoreStub implements RandomStubInterface
+{
+    /**
+     * @param string $value
+     *
+     * @return Ignore
+     */
+    public static function create($value)
+    {
+        return new Ignore($value);
+    }
+
+    /**
+     * @return Ignore
+     */
+    public static function random()
+    {
+        return self::create(StubCreator::faker()->word);
+    }
+}

--- a/src/PhpGitHooks/Module/Configuration/Tests/Stub/PhpCsResponseStub.php
+++ b/src/PhpGitHooks/Module/Configuration/Tests/Stub/PhpCsResponseStub.php
@@ -7,16 +7,18 @@ use PhpGitHooks\Module\Configuration\Contract\Response\PhpCsResponse;
 class PhpCsResponseStub
 {
     const STANDARD = 'PSR2';
+    const IGNORE = '';
 
     /**
      * @param bool   $phpCs
      * @param string $phpCsStandard
+     * @param string $ignore
      *
      * @return PhpCsResponse
      */
-    public static function create($phpCs, $phpCsStandard)
+    public static function create($phpCs, $phpCsStandard, $ignore)
     {
-        return new PhpCsResponse($phpCs, $phpCsStandard);
+        return new PhpCsResponse($phpCs, $phpCsStandard, $ignore);
     }
 
     /**
@@ -24,6 +26,6 @@ class PhpCsResponseStub
      */
     public static function createEnabled()
     {
-        return self::create(true, self::STANDARD);
+        return self::create(true, self::STANDARD, self::IGNORE);
     }
 }

--- a/src/PhpGitHooks/Module/Configuration/Tests/Stub/PhpCsStub.php
+++ b/src/PhpGitHooks/Module/Configuration/Tests/Stub/PhpCsStub.php
@@ -3,6 +3,7 @@
 namespace PhpGitHooks\Module\Configuration\Tests\Stub;
 
 use PhpGitHooks\Module\Configuration\Domain\Enabled;
+use PhpGitHooks\Module\Configuration\Domain\Ignore;
 use PhpGitHooks\Module\Configuration\Domain\PhpCs;
 use PhpGitHooks\Module\Configuration\Domain\PhpCsStandard;
 use PhpGitHooks\Module\Configuration\Domain\Undefined;
@@ -14,12 +15,13 @@ class PhpCsStub implements RandomStubInterface
      * @param Undefined     $undefined
      * @param Enabled       $enabled
      * @param PhpCsStandard $standard
+     * @param Ignore        $ignore
      *
      * @return PhpCs
      */
-    public static function create(Undefined $undefined, Enabled $enabled, PhpCsStandard $standard)
+    public static function create(Undefined $undefined, Enabled $enabled, PhpCsStandard $standard, Ignore $ignore)
     {
-        return new PhpCs($undefined, $enabled, $standard);
+        return new PhpCs($undefined, $enabled, $standard, $ignore);
     }
 
     /**
@@ -27,16 +29,27 @@ class PhpCsStub implements RandomStubInterface
      */
     public static function random()
     {
-        return self::create(new Undefined(false), EnabledStub::random(), PhpCsStandardStub::random());
+        return self::create(
+            new Undefined(false),
+            EnabledStub::random(),
+            PhpCsStandardStub::random(),
+            IgnoreStub::random()
+        );
     }
 
     /**
      * @param string $standard
+     * @param string $ignore
      *
      * @return PhpCs
      */
-    public static function createEnabled($standard = 'PSR2')
+    public static function createEnabled($standard = 'PSR2', $ignore = '*/migrations/*')
     {
-        return self::create(new Undefined(false), EnabledStub::create(true), PhpCsStandardStub::create($standard));
+        return self::create(
+            new Undefined(false),
+            EnabledStub::create(true),
+            PhpCsStandardStub::create($standard),
+            IgnoreStub::create($ignore)
+        );
     }
 }

--- a/src/PhpGitHooks/Module/Git/Service/PreCommitTool.php
+++ b/src/PhpGitHooks/Module/Git/Service/PreCommitTool.php
@@ -129,7 +129,8 @@ class PreCommitTool
                     new PhpCsToolCommand(
                         $phpFiles,
                         $phpCsResponse->getPhpCsStandard(),
-                        $preCommitResponse->getErrorMessage()
+                        $preCommitResponse->getErrorMessage(),
+                        $phpCsResponse->getIgnore()
                     )
                 );
             }

--- a/src/PhpGitHooks/Module/Git/Tests/Behaviour/PreCommitToolCommandHandlerTest.php
+++ b/src/PhpGitHooks/Module/Git/Tests/Behaviour/PreCommitToolCommandHandlerTest.php
@@ -84,7 +84,8 @@ class PreCommitToolCommandHandlerTest extends GitUnitTestCase
             new PhpCsToolCommand(
                 $files,
                 $configurationDataResponse->getPreCommit()->getPhpCs()->getPhpCsStandard(),
-                HookQuestions::PRE_COMMIT_ERROR_MESSAGE_DEFAULT
+                HookQuestions::PRE_COMMIT_ERROR_MESSAGE_DEFAULT,
+                $configurationDataResponse->getPreCommit()->getPhpCs()->getIgnore()
             )
         );
         $this->shouldHandleCommand(

--- a/src/PhpGitHooks/Module/PhpCs/Contract/Command/PhpCsToolCommand.php
+++ b/src/PhpGitHooks/Module/PhpCs/Contract/Command/PhpCsToolCommand.php
@@ -18,6 +18,10 @@ class PhpCsToolCommand implements CommandInterface
      * @var string
      */
     private $errorMessage;
+    /**
+     * @var string
+     */
+    private $ignore;
 
     /**
      * PhpCsToolCommand constructor.
@@ -26,11 +30,12 @@ class PhpCsToolCommand implements CommandInterface
      * @param string $standard
      * @param string $errorMessage
      */
-    public function __construct(array $files, $standard, $errorMessage)
+    public function __construct(array $files, $standard, $errorMessage, $ignore)
     {
         $this->files = $files;
         $this->standard = $standard;
         $this->errorMessage = $errorMessage;
+        $this->ignore = $ignore;
     }
 
     /**
@@ -55,5 +60,10 @@ class PhpCsToolCommand implements CommandInterface
     public function getStandard()
     {
         return $this->standard;
+    }
+
+    public function getIgnore()
+    {
+        return $this->ignore;
     }
 }

--- a/src/PhpGitHooks/Module/PhpCs/Contract/Command/PhpCsToolCommand.php
+++ b/src/PhpGitHooks/Module/PhpCs/Contract/Command/PhpCsToolCommand.php
@@ -29,6 +29,7 @@ class PhpCsToolCommand implements CommandInterface
      * @param array  $files
      * @param string $standard
      * @param string $errorMessage
+     * @param string $ignore
      */
     public function __construct(array $files, $standard, $errorMessage, $ignore)
     {
@@ -62,6 +63,9 @@ class PhpCsToolCommand implements CommandInterface
         return $this->standard;
     }
 
+    /**
+     * @return string
+     */
     public function getIgnore()
     {
         return $this->ignore;

--- a/src/PhpGitHooks/Module/PhpCs/Contract/CommandHandler/PhpCsToolCommandHandler.php
+++ b/src/PhpGitHooks/Module/PhpCs/Contract/CommandHandler/PhpCsToolCommandHandler.php
@@ -29,6 +29,6 @@ class PhpCsToolCommandHandler implements CommandHandlerInterface
      */
     public function handle(CommandInterface $command)
     {
-        $this->phpCsTool->execute($command->getFiles(), $command->getStandard(), $command->getErrorMessage());
+        $this->phpCsTool->execute($command->getFiles(), $command->getStandard(), $command->getErrorMessage(), $command->getIgnore());
     }
 }

--- a/src/PhpGitHooks/Module/PhpCs/Infrastructure/Tool/PhpCsToolProcessor.php
+++ b/src/PhpGitHooks/Module/PhpCs/Infrastructure/Tool/PhpCsToolProcessor.php
@@ -27,12 +27,13 @@ class PhpCsToolProcessor implements PhpCsToolProcessorInterface
     /**
      * @param string $file
      * @param string $standard
+     * @param string $ignore
      *
      * @return string
      */
-    public function process($file, $standard)
+    public function process($file, $standard, $ignore)
     {
-        $process = $this->execute($file, $standard);
+        $process = $this->execute($file, $standard, $ignore);
 
         return $this->setErrors($process);
     }
@@ -40,16 +41,18 @@ class PhpCsToolProcessor implements PhpCsToolProcessorInterface
     /**
      * @param string $file
      * @param string $standard
+     * @param string $ignore
      *
      * @return Process
      */
-    private function execute($file, $standard)
+    private function execute($file, $standard, $ignore)
     {
         $processBuilder = new ProcessBuilder(
             [
                 'php',
                 $this->toolPathFinder->find('phpcs'),
                 '--standard='.$standard,
+                '--ignore='.$ignore,
                 $file,
             ]
         );

--- a/src/PhpGitHooks/Module/PhpCs/Model/PhpCsToolProcessorInterface.php
+++ b/src/PhpGitHooks/Module/PhpCs/Model/PhpCsToolProcessorInterface.php
@@ -7,8 +7,9 @@ interface PhpCsToolProcessorInterface
     /**
      * @param string $file
      * @param string $standard
+     * @param string $ignore
      *
      * @return string
      */
-    public function process($file, $standard);
+    public function process($file, $standard, $ignore);
 }

--- a/src/PhpGitHooks/Module/PhpCs/Service/PhpCsTool.php
+++ b/src/PhpGitHooks/Module/PhpCs/Service/PhpCsTool.php
@@ -36,17 +36,18 @@ class PhpCsTool
      * @param array  $files
      * @param string $standard
      * @param string $errorMessage
+     * @param string $ignore
      *
      * @throws PhpCsViolationException
      */
-    public function execute(array $files, $standard, $errorMessage)
+    public function execute(array $files, $standard, $errorMessage, $ignore)
     {
         $outputMessage = new PreCommitOutputWriter(self::EXECUTE_MESSAGE);
         $this->output->write($outputMessage->getMessage());
 
         $errors = [];
         foreach ($files as $file) {
-            $errors[] = $this->phpCsToolProcessor->process($file, $standard);
+            $errors[] = $this->phpCsToolProcessor->process($file, $standard, $ignore);
         }
 
         $errors = array_filter($errors);

--- a/src/PhpGitHooks/Module/PhpCs/Tests/Behaviour/PhpCsToolCommandHandlerTest.php
+++ b/src/PhpGitHooks/Module/PhpCs/Tests/Behaviour/PhpCsToolCommandHandlerTest.php
@@ -44,7 +44,7 @@ class PhpCsToolCommandHandlerTest extends PhpCsUnitTestCase
         $errorTxt = null;
         foreach ($files as $file) {
             $error = 'ERROR-';
-            $this->shouldProcessPhpCsTool($file, 'PSR2', $error);
+            $this->shouldProcessPhpCsTool($file, 'PSR2', '', $error);
             $errorTxt .= $error;
         }
 
@@ -56,7 +56,8 @@ class PhpCsToolCommandHandlerTest extends PhpCsUnitTestCase
             new PhpCsToolCommand(
                 $files,
                 'PSR2',
-                HookQuestions::PRE_COMMIT_ERROR_MESSAGE_DEFAULT
+                HookQuestions::PRE_COMMIT_ERROR_MESSAGE_DEFAULT,
+                ''
             )
         );
     }
@@ -72,7 +73,7 @@ class PhpCsToolCommandHandlerTest extends PhpCsUnitTestCase
         $this->shouldWriteOutput($output->getMessage());
 
         foreach ($files as $file) {
-            $this->shouldProcessPhpCsTool($file, 'PSR2', null);
+            $this->shouldProcessPhpCsTool($file, 'PSR2', '', null);
         }
 
         $this->shouldWriteLnOutput($output->getSuccessfulMessage());
@@ -81,7 +82,8 @@ class PhpCsToolCommandHandlerTest extends PhpCsUnitTestCase
             new PhpCsToolCommand(
                 $files,
                 'PSR2',
-                HookQuestions::PRE_COMMIT_ERROR_MESSAGE_DEFAULT
+                HookQuestions::PRE_COMMIT_ERROR_MESSAGE_DEFAULT,
+                ''
             )
         );
     }

--- a/src/PhpGitHooks/Module/PhpCs/Tests/Infrastructure/PhpCsToolProcessorTrait.php
+++ b/src/PhpGitHooks/Module/PhpCs/Tests/Infrastructure/PhpCsToolProcessorTrait.php
@@ -24,14 +24,15 @@ trait PhpCsToolProcessorTrait
     /**
      * @param string $file
      * @param string $standard
+     * @param string $ignore
      * @param string $return
      */
-    protected function shouldProcessPhpCsTool($file, $standard, $return)
+    protected function shouldProcessPhpCsTool($file, $standard, $ignore, $return)
     {
         $this->getPhpCsToolProcessor()
             ->shouldReceive('process')
             ->once()
-            ->withArgs([$file, $standard])
+            ->withArgs([$file, $standard, $ignore])
             ->andReturn($return);
     }
 }


### PR DESCRIPTION
Hey,

I've been using php-git-hooks in a while in some of the projects, thank you for this great solution which makes it easier to keep code nice and clean!

However, some of the projects using either outdated code base, or at least contain some "heavy" parts which are always a topic for refactoring.
Recently I've been missing the configuration option to pass ignore patterns to PHPCS to specify the path for files which doesn't have to be checked and I wasn't able to find a way to do it with php-git-hooks, even if PHPCS supports the `--ignore` option.

So, I've implemented a feature to be able to use that option with php-git-hooks.
Not sure if there was a way to do it with IgnoreFiles, so it's made as it is right now.

P.S. Probably, the Ignore class should be named differently, but I had no better idea at the moment :)