### PR TITLE
php unit 7.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.1",
         "friendsofphp/php-cs-fixer": "^2.1",
-        "phpunit/phpunit": "~6.0",
+        "phpunit/phpunit": "~7.0",
         "squizlabs/php_codesniffer": "~2.8",
         "phpmd/phpmd": "~2.6",
         "symfony/dependency-injection": "~4.0",


### PR DESCRIPTION
Because I am using Laravel 5.6 which uses PHP Unit 7.0 I just updated the version.