### PR TITLE
Set the content of the error output

### DIFF
--- a/src/PhpGitHooks/Module/JsonLint/Infrastructure/Tool/JsonLintProcessor.php
+++ b/src/PhpGitHooks/Module/JsonLint/Infrastructure/Tool/JsonLintProcessor.php
@@ -63,7 +63,7 @@ class JsonLintProcessor implements JsonLintProcessorInterface
     private function setErrors(Process $process)
     {
         if (false === $process->isSuccessful()) {
-            return $process->getOutput();
+            return $process->getErrorOutput();
         }
     }
 }

--- a/src/PhpGitHooks/Module/PhpCs/Infrastructure/Tool/PhpCsToolProcessor.php
+++ b/src/PhpGitHooks/Module/PhpCs/Infrastructure/Tool/PhpCsToolProcessor.php
@@ -69,7 +69,7 @@ class PhpCsToolProcessor implements PhpCsToolProcessorInterface
     private function setErrors(Process $process)
     {
         if (false === $process->isSuccessful()) {
-            return $process->getOutput();
+            return $process->getErrorOutput();
         }
     }
 }

--- a/src/PhpGitHooks/Module/PhpCsFixer/Infrastructure/Tool/PhpCsFixerToolProcessor.php
+++ b/src/PhpGitHooks/Module/PhpCsFixer/Infrastructure/Tool/PhpCsFixerToolProcessor.php
@@ -74,7 +74,7 @@ class PhpCsFixerToolProcessor implements PhpCsFixerToolProcessorInterface
     private function setError(Process $process)
     {
         if (false === $process->isSuccessful()) {
-            return $process->getOutput();
+            return $process->getErrorOutput();
         }
     }
 }

--- a/src/PhpGitHooks/Module/PhpLint/Infrastructure/Tool/PhpLintToolProcessor.php
+++ b/src/PhpGitHooks/Module/PhpLint/Infrastructure/Tool/PhpLintToolProcessor.php
@@ -46,6 +46,6 @@ class PhpLintToolProcessor implements PhpLintToolProcessorInterface
      */
     private function setErrors(Process $process)
     {
-        return false === $process->isSuccessful() ? $process->getOutput() : null;
+        return false === $process->isSuccessful() ? $process->getErrorOutput() : null;
     }
 }

--- a/src/PhpGitHooks/Module/PhpMd/Infrastructure/Tool/PhpMdToolProcessor.php
+++ b/src/PhpGitHooks/Module/PhpMd/Infrastructure/Tool/PhpMdToolProcessor.php
@@ -59,6 +59,6 @@ class PhpMdToolProcessor implements PhpMdToolProcessorInterface
      */
     private function setError(Process $process)
     {
-        return false === $process->isSuccessful() ? $process->getOutput() : null;
+        return false === $process->isSuccessful() ? $process->getErrorOutput() : null;
     }
 }


### PR DESCRIPTION
The getOutput() method always returns the whole content of the standard output of the command and getErrorOutput() the content of the error output