### PR TITLE
Phpmd error msg fix

### DIFF
--- a/src/PhpGitHooks/Module/PhpMd/Infrastructure/Tool/PhpMdToolProcessor.php
+++ b/src/PhpGitHooks/Module/PhpMd/Infrastructure/Tool/PhpMdToolProcessor.php
@@ -57,8 +57,20 @@ class PhpMdToolProcessor implements PhpMdToolProcessorInterface
      *
      * @return null|string
      */
+
+    /**
+     * @param Process $process
+     *
+     * @return null|string
+     *
+     * @throws \Symfony\Component\Process\Exception\LogicException
+     */
     private function setError(Process $process)
     {
-        return false === $process->isSuccessful() ? $process->getErrorOutput() : null;
+        if (false === $process->isSuccessful()) {
+            return $process->getErrorOutput() ?: $process->getOutput();
+        }
+
+        return null;
     }
 }

--- a/src/PhpGitHooks/Module/PhpMd/Infrastructure/Tool/PhpMdToolProcessor.php
+++ b/src/PhpGitHooks/Module/PhpMd/Infrastructure/Tool/PhpMdToolProcessor.php
@@ -56,12 +56,6 @@ class PhpMdToolProcessor implements PhpMdToolProcessorInterface
      * @param Process $process
      *
      * @return null|string
-     */
-
-    /**
-     * @param Process $process
-     *
-     * @return null|string
      *
      * @throws \Symfony\Component\Process\Exception\LogicException
      */


### PR DESCRIPTION
Hola @bruli 

When the exit code is 1 (an error/exception occurred which has interrupted PHPMD during execution), PHPMD sends error messages to stderr.

When the exit code is 2 (PHPMD has processed the code under test without the occurrence of an error/exception, but it has detected rule violations in the analyzed source code), PHPMD sends error messages to stdout.

