### PR TITLE
Add support of fiunchinho/phpunit-randomizer v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "symfony/dependency-injection": "~4.0",
         "symfony/config": "~4.0",
         "symfony/yaml": "~4.0",
-        "fiunchinho/phpunit-randomizer": "~4.0",
+        "fiunchinho/phpunit-randomizer": "~3.0|~4.0",
         "seld/jsonlint": "~1.5",
         "bruli/ignore-files": "~1.0",
         "beberlei/assert": "~2.7",


### PR DESCRIPTION
Since the library `fiunchinho/phpunit-randomizer` v4 requires `phpunit/phpunit` v7, it's not possible to require the last version of `bruli/php-git-hooks` when `phpunit/phpunit` v6 is installed.