### PR TITLE
Fix coverage validation for phpunit 7 (backguards compatibility.

### DIFF
--- a/src/PhpGitHooks/Module/PhpUnit/Infrastructure/Tool/StrictCoverageProcessor.php
+++ b/src/PhpGitHooks/Module/PhpUnit/Infrastructure/Tool/StrictCoverageProcessor.php
@@ -29,7 +29,7 @@ class StrictCoverageProcessor implements StrictCoverageProcessorInterface
     public function process()
     {
         $tool = $this->toolPathFinder->find('phpunit');
-        $command = 'php '.$tool.' --coverage-text|grep Classes|cut -d " " -f 5|cut -d "%" -f 1';
+        $command = 'php '.$tool.' --coverage-text|grep Classes| tr -s \' \' |cut -d " " -f 3|cut -d "%" -f 1';
 
         $process = new Process($command);
         $process->run();


### PR DESCRIPTION
With the new PHPUnit 7.4 version
It seems that there are less spaces.

In previous versions
`··Classes:··100.00%·(56/56)`

In actual version
`··Classes:·100.00%·(2/2)`

I have done a little change in order to convert multiple spaces into one, so the number of columns will be the same both in phpunit 6 and 7