### PR TITLE
add enable faces in messages config option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 composer.phar
 vendor/
 bin/
+.idea/
 php-git-hooks.yml
 # Commit your application's lock file http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
@@ -9,7 +10,6 @@ composer.lock
 .guard_coverage
 var/cache
 var/logs
-.php_cs.cache
 
 ###> friendsofphp/php-cs-fixer ###
 .php_cs

--- a/php-git-hooks.yml.sample
+++ b/php-git-hooks.yml.sample
@@ -29,6 +29,7 @@ pre-commit:
         options:     '<some options>'
     composer:        true
   message:
+    enable-faces: true
     right-message: 'HEY, GOOD JOB!!'
     error-message: 'FIX YOUR CODE!!'
 commit-msg:
@@ -48,5 +49,6 @@ pre-push:
         enabled: true
         message: 'WARNING!!, your code coverage is lower.'
     message:
+      enable-faces: true
       right-message: 'PUSH IT!!'
       error-message: 'YOU CAN NOT PUSH CODE!!'

--- a/src/PhpGitHooks/Infrastructure/Composer/ConfiguratorScript.php
+++ b/src/PhpGitHooks/Infrastructure/Composer/ConfiguratorScript.php
@@ -18,8 +18,6 @@ class ConfiguratorScript
 {
     /**
      * @param Event $event
-     *
-     * @return mixed
      */
     public static function buildConfig(Event $event)
     {

--- a/src/PhpGitHooks/Module/Composer/Contract/Command/ComposerTool.php
+++ b/src/PhpGitHooks/Module/Composer/Contract/Command/ComposerTool.php
@@ -14,17 +14,23 @@ class ComposerTool implements CommandInterface
      * @var string
      */
     private $errorMessage;
+    /**
+     * @var bool
+     */
+    private $enableFaces;
 
     /**
      * ComposerToolCommand constructor.
      *
-     * @param array  $files
+     * @param array $files
      * @param string $errorMessage
+     * @param bool $enableFaces
      */
-    public function __construct(array $files, $errorMessage)
+    public function __construct(array $files, $errorMessage, $enableFaces)
     {
         $this->files = $files;
         $this->errorMessage = $errorMessage;
+        $this->enableFaces = $enableFaces;
     }
 
     /**
@@ -33,6 +39,14 @@ class ComposerTool implements CommandInterface
     public function getErrorMessage()
     {
         return $this->errorMessage;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEnableFaces()
+    {
+        return $this->enableFaces;
     }
 
     /**

--- a/src/PhpGitHooks/Module/Composer/Contract/Command/ComposerToolHandler.php
+++ b/src/PhpGitHooks/Module/Composer/Contract/Command/ComposerToolHandler.php
@@ -43,19 +43,22 @@ class ComposerToolHandler implements CommandHandlerInterface
 
     /**
      * @param CommandInterface|ComposerTool $command
-     */
-    public function handle(CommandInterface $command)
-    {
-        $this->execute($command->getFiles(), $command->getErrorMessage());
-    }
-
-    /**
-     * @param array  $files
-     * @param string $errorMessage
      *
      * @throws ComposerFilesNotFoundException
      */
-    private function execute(array $files, $errorMessage)
+    public function handle(CommandInterface $command)
+    {
+        $this->execute($command->getFiles(), $command->getErrorMessage(), $command->isEnableFaces());
+    }
+
+    /**
+     * @param array $files
+     * @param string $errorMessage
+     * @param bool $enableFaces
+     *
+     * @throws ComposerFilesNotFoundException
+     */
+    private function execute(array $files, $errorMessage, $enableFaces)
     {
         $composerFilesResponse = $this->getComposerFilesResponse($files);
 
@@ -66,24 +69,26 @@ class ComposerToolHandler implements CommandHandlerInterface
             $this->executeTool(
                 $composerFilesResponse->isJsonFile(),
                 $composerFilesResponse->isLockFile(),
-                $errorMessage
+                $errorMessage,
+                $enableFaces
             );
             $this->output->writeln($this->outputMessage->getSuccessfulMessage());
         }
     }
 
     /**
-     * @param bool   $jsonFile
-     * @param bool   $lockFile
+     * @param bool $jsonFile
+     * @param bool $lockFile
      * @param string $errorMessage
+     * @param bool $enableFaces
      *
      * @throws ComposerFilesNotFoundException *
      */
-    private function executeTool($jsonFile, $lockFile, $errorMessage)
+    private function executeTool($jsonFile, $lockFile, $errorMessage, $enableFaces)
     {
         if (true === $jsonFile && false === $lockFile) {
             $this->output->writeln($this->outputMessage->getFailMessage());
-            $this->output->writeln(BadJobLogoResponse::paint($errorMessage));
+            $this->output->writeln(BadJobLogoResponse::paint($errorMessage, $enableFaces));
             throw new ComposerFilesNotFoundException();
         }
     }

--- a/src/PhpGitHooks/Module/Composer/Tests/Behaviour/ComposerToolHandlerTest.php
+++ b/src/PhpGitHooks/Module/Composer/Tests/Behaviour/ComposerToolHandlerTest.php
@@ -35,6 +35,7 @@ class ComposerToolHandlerTest extends ComposerUnitTestCase
 
     /**
      * @test
+     * @throws ComposerFilesNotFoundException
      */
     public function itShouldWorksFine()
     {
@@ -49,12 +50,13 @@ class ComposerToolHandlerTest extends ComposerUnitTestCase
         $this->shouldWriteLnOutput($output->getSuccessfulMessage());
 
         $this->composerToolCommandHandler->handle(
-            new ComposerTool($files, $this->errorMessage)
+            new ComposerTool($files, $this->errorMessage, true)
         );
     }
 
     /**
      * @test
+     * @throws ComposerFilesNotFoundException
      */
     public function itShouldThrowException()
     {
@@ -69,15 +71,16 @@ class ComposerToolHandlerTest extends ComposerUnitTestCase
             ComposerFilesResponseStub::createInvalidData()
         );
         $this->shouldWriteLnOutput($output->getFailMessage());
-        $this->shouldWriteLnOutput(BadJobLogoResponse::paint($this->errorMessage));
+        $this->shouldWriteLnOutput(BadJobLogoResponse::paint($this->errorMessage, true));
 
         $this->composerToolCommandHandler->handle(
-            new ComposerTool($files, $this->errorMessage)
+            new ComposerTool($files, $this->errorMessage, true)
         );
     }
 
     /**
      * @test
+     * @throws ComposerFilesNotFoundException
      */
     public function itShouldNotExecuteComposerTool()
     {
@@ -88,6 +91,6 @@ class ComposerToolHandlerTest extends ComposerUnitTestCase
             ComposerFilesResponseStub::createNoData()
         );
 
-        $this->composerToolCommandHandler->handle(new ComposerTool($files, $this->errorMessage));
+        $this->composerToolCommandHandler->handle(new ComposerTool($files, $this->errorMessage, true));
     }
 }

--- a/src/PhpGitHooks/Module/Configuration/Contract/Response/PreCommitResponse.php
+++ b/src/PhpGitHooks/Module/Configuration/Contract/Response/PreCommitResponse.php
@@ -19,6 +19,10 @@ class PreCommitResponse
     /**
      * @var bool
      */
+    private $enableFaces;
+    /**
+     * @var bool
+     */
     private $composer;
     /**
      * @var bool
@@ -56,23 +60,25 @@ class PreCommitResponse
     /**
      * PreCommitResponse constructor.
      *
-     * @param bool                          $preCommit
-     * @param string                        $rightMessage
-     * @param string                        $errorMessage
-     * @param bool                          $composer
-     * @param bool                          $jsonLint
-     * @param bool                          $phpLint
-     * @param PhpMdResponse                 $phpMd
-     * @param PhpCsResponse                 $phpCs
-     * @param PhpCsFixerResponse            $phpCsFixer
-     * @param PhpUnitResponse               $phpUnit
+     * @param bool $preCommit
+     * @param string $rightMessage
+     * @param string $errorMessage
+     * @param bool $enableFaces
+     * @param bool $composer
+     * @param bool $jsonLint
+     * @param bool $phpLint
+     * @param PhpMdResponse $phpMd
+     * @param PhpCsResponse $phpCs
+     * @param PhpCsFixerResponse $phpCsFixer
+     * @param PhpUnitResponse $phpUnit
      * @param PhpUnitStrictCoverageResponse $phpUnitStrictCoverage
-     * @param PhpUnitGuardCoverageResponse  $phpUnitGuardCoverage
+     * @param PhpUnitGuardCoverageResponse $phpUnitGuardCoverage
      */
     public function __construct(
         $preCommit,
         $rightMessage,
         $errorMessage,
+        $enableFaces,
         $composer,
         $jsonLint,
         $phpLint,
@@ -86,6 +92,7 @@ class PreCommitResponse
         $this->preCommit = $preCommit;
         $this->rightMessage = $rightMessage;
         $this->errorMessage = $errorMessage;
+        $this->enableFaces = $enableFaces;
         $this->composer = $composer;
         $this->jsonLint = $jsonLint;
         $this->phpLint = $phpLint;
@@ -119,6 +126,14 @@ class PreCommitResponse
     public function getErrorMessage()
     {
         return $this->errorMessage;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEnableFaces()
+    {
+        return $this->enableFaces;
     }
 
     /**

--- a/src/PhpGitHooks/Module/Configuration/Contract/Response/PrePushResponse.php
+++ b/src/PhpGitHooks/Module/Configuration/Contract/Response/PrePushResponse.php
@@ -25,6 +25,10 @@ class PrePushResponse
      */
     private $errorMessage;
     /**
+     * @var bool
+     */
+    private $enableFaces;
+    /**
      * @var PhpUnitGuardCoverageResponse
      */
     private $phpUnitGuardCoverage;
@@ -32,17 +36,19 @@ class PrePushResponse
     /**
      * PrePushResponse constructor.
      *
-     * @param bool                          $prePush
-     * @param string                        $rightMessage
-     * @param string                        $errorMessage
-     * @param PhpUnitResponse               $phpUnit
+     * @param bool $prePush
+     * @param string $rightMessage
+     * @param string $errorMessage
+     * @param bool $enableFaces
+     * @param PhpUnitResponse $phpUnit
      * @param PhpUnitStrictCoverageResponse $phpUnitStrictCoverage
-     * @param PhpUnitGuardCoverageResponse  $phpUnitGuardCoverage
+     * @param PhpUnitGuardCoverageResponse $phpUnitGuardCoverage
      */
     public function __construct(
         $prePush,
         $rightMessage,
         $errorMessage,
+        $enableFaces,
         PhpUnitResponse $phpUnit,
         PhpUnitStrictCoverageResponse $phpUnitStrictCoverage,
         PhpUnitGuardCoverageResponse $phpUnitGuardCoverage
@@ -52,6 +58,7 @@ class PrePushResponse
         $this->prePush = $prePush;
         $this->rightMessage = $rightMessage;
         $this->errorMessage = $errorMessage;
+        $this->enableFaces = $enableFaces;
         $this->phpUnitGuardCoverage = $phpUnitGuardCoverage;
     }
 
@@ -93,6 +100,14 @@ class PrePushResponse
     public function getErrorMessage()
     {
         return $this->errorMessage;
+    }
+
+    /**
+     * @return string
+     */
+    public function isEnableFaces()
+    {
+        return $this->enableFaces;
     }
 
     /**

--- a/src/PhpGitHooks/Module/Configuration/Domain/Messages.php
+++ b/src/PhpGitHooks/Module/Configuration/Domain/Messages.php
@@ -14,15 +14,22 @@ class Messages
     private $errorMessage;
 
     /**
+     * @var Enabled
+     */
+    private $enableFaces;
+
+    /**
      * Messages constructor.
      *
      * @param Message $rightMessage
      * @param Message $errorMessage
+     * @param Enabled $enableFaces
      */
-    public function __construct(Message $rightMessage, Message $errorMessage)
+    public function __construct(Message $rightMessage, Message $errorMessage, Enabled $enableFaces)
     {
         $this->rightMessage = $rightMessage;
         $this->errorMessage = $errorMessage;
+        $this->enableFaces = $enableFaces;
     }
 
     /**
@@ -42,13 +49,22 @@ class Messages
     }
 
     /**
+     * @return Enabled
+     */
+    public function getEnableFaces()
+    {
+        return $this->enableFaces;
+    }
+
+    /**
      * @return Messages
      */
     public function disable()
     {
         return new self(
             new Message(null),
-            new Message(null)
+            new Message(null),
+            new Enabled(true)
         );
     }
 }

--- a/src/PhpGitHooks/Module/Configuration/Service/ConfigurationArrayTransformer.php
+++ b/src/PhpGitHooks/Module/Configuration/Service/ConfigurationArrayTransformer.php
@@ -89,6 +89,7 @@ class ConfigurationArrayTransformer
                     ],
                 ],
                 'message' => [
+                    'enable-faces' => $preCommit->getMessages()->getEnableFaces()->value(),
                     'right-message' => $preCommit->getMessages()->getRightMessage()->value(),
                     'error-message' => $preCommit->getMessages()->getErrorMessage()->value(),
                 ],
@@ -115,6 +116,7 @@ class ConfigurationArrayTransformer
                     ],
                 ],
                 'message' => [
+                    'enable-faces' => $preCommit->getMessages()->getEnableFaces()->value(),
                     'right-message' => $prePush->getMessages()->getRightMessage()->value(),
                     'error-message' => $prePush->getMessages()->getErrorMessage()->value(),
                 ],

--- a/src/PhpGitHooks/Module/Configuration/Service/ConfigurationDataResponseFactory.php
+++ b/src/PhpGitHooks/Module/Configuration/Service/ConfigurationDataResponseFactory.php
@@ -72,6 +72,7 @@ class ConfigurationDataResponseFactory
             $prePush->isEnabled(),
             $prePush->getMessages()->getRightMessage(),
             $prePush->getMessages()->getErrorMessage(),
+            $prePush->getMessages()->getEnableFaces()->value(),
             new PhpUnitResponse(
                 $prePushPhpUnit->isEnabled(),
                 $prePushPhpUnit->getRandomMode()->value(),
@@ -91,6 +92,7 @@ class ConfigurationDataResponseFactory
             $preCommit->isEnabled(),
             $preCommit->getMessages()->getRightMessage()->value(),
             $preCommit->getMessages()->getErrorMessage()->value(),
+            $preCommit->getMessages()->getEnableFaces()->value(),
             $composer->isEnabled(),
             $jsonLint->isEnabled(),
             $phpLint->isEnabled(),

--- a/src/PhpGitHooks/Module/Configuration/Service/HookQuestions.php
+++ b/src/PhpGitHooks/Module/Configuration/Service/HookQuestions.php
@@ -12,6 +12,7 @@ class HookQuestions
     const PRE_COMMIT_ERROR_MESSAGE = '<info>Write an error message for pre-commit hook:</info> '.
     '<comment>'.self::PRE_COMMIT_ERROR_MESSAGE_DEFAULT.'</comment>';
     const PRE_COMMIT_ERROR_MESSAGE_DEFAULT = 'FIX YOUR FUCKING CODE!!';
+    const PRE_COMMIT_ENABLE_FACES_MESSAGE = '<info>Enable face in messages for pre-commit hook?:</info> <comment>[Y/n]</comment>';
     const COMPOSER_TOOL = '<info>Do you want enable COMPOSER tool?:</info> <comment>[Y/n]</comment>';
     const JSONLINT_TOOL = '<info>Do you want enable JSONLINT tool?:</info> <comment>[Y/n]</comment>';
     const PHPLINT_TOOL = '<info>Do you want enable PHPLINT tool?:</info> <comment>[Y/n]</comment>';
@@ -43,6 +44,7 @@ class HookQuestions
     const PRE_PUSH_ERROR_MESSAGE_DEFAULT = 'YOU CAN NOT PUSH CODE!!';
     const PRE_PUSH_ERROR_MESSAGE = '<info>Write an error message for pre-push hook:</info> '.
     '<comment>'.self::PRE_PUSH_ERROR_MESSAGE_DEFAULT.'</comment>';
+    const PRE_PUSH_ENABLE_FACES_MESSAGE = '<info>Enable face in messages for pre-push hook?:</info> <comment>[Y/n]</comment>';
     const PHPUNIT_STRICT_COVERAGE = '<info>Do you want enable STRICT COVERAGE tool?:</info> <comment>[Y/n]</comment>';
     const PHPUNIT_STRICT_COVERAGE_MINIMUM = '<info>Write minimum coverage to guard:</info> <comment>[0.00]</comment>';
     const PHPUNIT_GUARD_COVERAGE = '<info>Do you want enable GUARD COVERAGE tool?:</info> <comment>[Y/n]</comment>';

--- a/src/PhpGitHooks/Module/Configuration/Service/MessagesFactory.php
+++ b/src/PhpGitHooks/Module/Configuration/Service/MessagesFactory.php
@@ -2,6 +2,7 @@
 
 namespace PhpGitHooks\Module\Configuration\Service;
 
+use PhpGitHooks\Module\Configuration\Domain\Enabled;
 use PhpGitHooks\Module\Configuration\Domain\Message;
 use PhpGitHooks\Module\Configuration\Domain\Messages;
 
@@ -16,7 +17,8 @@ class MessagesFactory
     {
         return new Messages(
             new Message(isset($data['right-message']) ? $data['right-message'] : ''),
-            new Message(isset($data['error-message']) ? $data['error-message'] : '')
+            new Message(isset($data['error-message']) ? $data['error-message'] : ''),
+            new Enabled(isset($data['error-message']) ? (bool)$data['error-message'] : true)
         );
     }
 
@@ -27,7 +29,8 @@ class MessagesFactory
     {
         return new Messages(
             new Message(null),
-            new Message(null)
+            new Message(null),
+            new Enabled(true)
         );
     }
 }

--- a/src/PhpGitHooks/Module/Configuration/Service/PreCommitConfigurator.php
+++ b/src/PhpGitHooks/Module/Configuration/Service/PreCommitConfigurator.php
@@ -27,10 +27,13 @@ class PreCommitConfigurator
                 ->ask(HookQuestions::PRE_COMMIT_RIGHT_MESSAGE, HookQuestions::PRE_COMMIT_RIGHT_MESSAGE_DEFAULT);
             $errorMessageAnswer = $io
                 ->ask(HookQuestions::PRE_COMMIT_ERROR_MESSAGE, HookQuestions::PRE_COMMIT_ERROR_MESSAGE_DEFAULT);
+            $enableFaces = $io
+                ->ask(HookQuestions::PRE_COMMIT_ENABLE_FACES_MESSAGE, HookQuestions::DEFAULT_TOOL_ANSWER);
 
             $preCommit = $preCommit->setMessages(new Messages(
                 new Message($rightMessageAnswer),
-                new Message($errorMessageAnswer)
+                new Message($errorMessageAnswer),
+                new Enabled(HookQuestions::DEFAULT_TOOL_ANSWER === strtoupper($enableFaces))
             ));
         }
 

--- a/src/PhpGitHooks/Module/Configuration/Service/PrePushConfigurator.php
+++ b/src/PhpGitHooks/Module/Configuration/Service/PrePushConfigurator.php
@@ -21,11 +21,14 @@ class PrePushConfigurator
                 ->ask(HookQuestions::PRE_PUSH_RIGHT_MESSAGE, HookQuestions::PRE_PUSH_RIGHT_MESSAGE_DEFAULT);
             $errorMessageAnswer = $input
                 ->ask(HookQuestions::PRE_PUSH_ERROR_MESSAGE, HookQuestions::PRE_PUSH_ERROR_MESSAGE_DEFAULT);
+            $enableFaces = $input
+                ->ask(HookQuestions::PRE_PUSH_ENABLE_FACES_MESSAGE, HookQuestions::DEFAULT_TOOL_ANSWER);
 
             $prePush = $prePush->setMessages(
                 new Messages(
                     new Message($rightMessageAnswer),
-                    new Message($errorMessageAnswer)
+                    new Message($errorMessageAnswer),
+                    new Enabled(HookQuestions::DEFAULT_TOOL_ANSWER === strtoupper($enableFaces))
                 )
             );
         }

--- a/src/PhpGitHooks/Module/Configuration/Tests/Behaviour/ConfigurationProcessorHandlerTest.php
+++ b/src/PhpGitHooks/Module/Configuration/Tests/Behaviour/ConfigurationProcessorHandlerTest.php
@@ -74,6 +74,11 @@ final class ConfigurationProcessorHandlerTest extends ConfigurationUnitTestCase
             HookQuestions::PRE_COMMIT_ERROR_MESSAGE_DEFAULT,
             ConfigArrayDataStub::ERROR_MESSAGE
         );
+        $this->shouldAsk(
+            HookQuestions::PRE_COMMIT_ENABLE_FACES_MESSAGE,
+            HookQuestions::DEFAULT_TOOL_ANSWER,
+            $yes
+        );
         $this->shouldAsk(HookQuestions::COMPOSER_TOOL, HookQuestions::DEFAULT_TOOL_ANSWER, $yes);
         $this->shouldAsk(HookQuestions::JSONLINT_TOOL, HookQuestions::DEFAULT_TOOL_ANSWER, $yes);
         $this->shouldAsk(HookQuestions::PHPLINT_TOOL, HookQuestions::DEFAULT_TOOL_ANSWER, $yes);
@@ -120,6 +125,11 @@ final class ConfigurationProcessorHandlerTest extends ConfigurationUnitTestCase
             HookQuestions::PRE_PUSH_ERROR_MESSAGE,
             HookQuestions::PRE_PUSH_ERROR_MESSAGE_DEFAULT,
             HookQuestions::PRE_PUSH_ERROR_MESSAGE_DEFAULT
+        );
+        $this->shouldAsk(
+            HookQuestions::PRE_PUSH_ENABLE_FACES_MESSAGE,
+            HookQuestions::DEFAULT_TOOL_ANSWER,
+            $yes
         );
         $this->shouldAsk(HookQuestions::PHPUNIT_TOOL, HookQuestions::DEFAULT_TOOL_ANSWER, $yes);
         $this->shouldAsk(HookQuestions::PHPUNIT_RANDOM_MODE, HookQuestions::DEFAULT_TOOL_ANSWER, $yes);

--- a/src/PhpGitHooks/Module/Configuration/Tests/Behaviour/PreCommitProcessorTest.php
+++ b/src/PhpGitHooks/Module/Configuration/Tests/Behaviour/PreCommitProcessorTest.php
@@ -50,6 +50,7 @@ class PreCommitProcessorTest extends ConfigurationUnitTestCase
         $this->assertFalse($preCommitData->isUndefined());
         $this->assertNull($preCommitData->getMessages()->getRightMessage()->value());
         $this->assertNull($preCommitData->getMessages()->getErrorMessage()->value());
+        $this->assertTrue($preCommitData->getMessages()->getEnableFaces()->value());
 
         /** @var Execute $execute */
         $execute = $preCommitData->getExecute();

--- a/src/PhpGitHooks/Module/Configuration/Tests/Stub/ConfigArrayDataStub.php
+++ b/src/PhpGitHooks/Module/Configuration/Tests/Stub/ConfigArrayDataStub.php
@@ -62,6 +62,7 @@ class ConfigArrayDataStub
                     ],
                 ],
                 'message' => [
+                    'enable-faces' => true,
                     'right-message' => static::RIGHT_MESSAGE,
                     'error-message' => static::ERROR_MESSAGE,
                 ],
@@ -88,6 +89,7 @@ class ConfigArrayDataStub
                     ]
                 ],
                 'message' => [
+                    'enable-faces' => true,
                     'right-message' => HookQuestions::PRE_PUSH_RIGHT_MESSAGE_DEFAULT,
                     'error-message' => HookQuestions::PRE_PUSH_ERROR_MESSAGE_DEFAULT,
                 ]

--- a/src/PhpGitHooks/Module/Configuration/Tests/Stub/ConfigurationDataResponseStub.php
+++ b/src/PhpGitHooks/Module/Configuration/Tests/Stub/ConfigurationDataResponseStub.php
@@ -50,6 +50,7 @@ final class ConfigurationDataResponseStub
                 $preCommit,
                 PreCommitResponseStub::GOOD_JOB,
                 PreCommitResponseStub::FIX_YOUR_CODE,
+                true,
                 $preCommit,
                 $preCommit,
                 $preCommit,
@@ -65,6 +66,7 @@ final class ConfigurationDataResponseStub
                 $prePush,
                 PrePushResponseStub::RIGHT_MESSAGE,
                 PrePushResponseStub::ERROR_MESSAGE,
+                true,
                 PhpUnitResponseStub::create($prePush, $prePush, PhpUnitResponseStub::OPTIONS),
                 PhpUnitStrictCoverageResponseStub::create($prePush, PhpUnitStrictCoverageResponseStub::MINIMUM),
                 PhpUnitGuardCoverageResponseStub::create($prePush, PhpUnitGuardCoverageResponseStub::WARNING_MESSAGE)

--- a/src/PhpGitHooks/Module/Configuration/Tests/Stub/MessagesStub.php
+++ b/src/PhpGitHooks/Module/Configuration/Tests/Stub/MessagesStub.php
@@ -2,6 +2,7 @@
 
 namespace PhpGitHooks\Module\Configuration\Tests\Stub;
 
+use PhpGitHooks\Module\Configuration\Domain\Enabled;
 use PhpGitHooks\Module\Configuration\Domain\Message;
 use PhpGitHooks\Module\Configuration\Domain\Messages;
 use PhpGitHooks\Module\Tests\Infrastructure\Stub\RandomStubInterface;
@@ -11,14 +12,13 @@ class MessagesStub implements RandomStubInterface
     /**
      * @param Message $rightMessage
      * @param Message $errorMessage
+     * @param Enabled $enableFaces
      *
      * @return Messages
      */
-    public static function create(
-        Message $rightMessage,
-        Message $errorMessage
-    ) {
-        return new Messages($rightMessage, $errorMessage);
+    public static function create(Message $rightMessage, Message $errorMessage, Enabled $enableFaces)
+    {
+        return new Messages($rightMessage, $errorMessage, $enableFaces);
     }
 
     /**
@@ -26,6 +26,6 @@ class MessagesStub implements RandomStubInterface
      */
     public static function random()
     {
-        return self::create(MessageStub::random(), MessageStub::random());
+        return self::create(MessageStub::random(), MessageStub::random(), EnabledStub::random());
     }
 }

--- a/src/PhpGitHooks/Module/Configuration/Tests/Stub/PreCommitResponseStub.php
+++ b/src/PhpGitHooks/Module/Configuration/Tests/Stub/PreCommitResponseStub.php
@@ -18,18 +18,19 @@ class PreCommitResponseStub
     const MINIMUM_COVERAGE = 100.00;
 
     /**
-     * @param bool                          $preCommit
-     * @param string                        $rightMessage
-     * @param string                        $errorMessage
-     * @param bool                          $composer
-     * @param bool                          $jsonLint
-     * @param bool                          $phpLint
-     * @param PhpMdResponse                 $pmdResponse
-     * @param PhpCsResponse                 $phpCsResponse
-     * @param PhpCsFixerResponse            $phpCsFixerResponse
-     * @param PhpUnitResponse               $phpUnitResponse
+     * @param bool $preCommit
+     * @param string $rightMessage
+     * @param string $errorMessage
+     * @param bool $enableFaces
+     * @param bool $composer
+     * @param bool $jsonLint
+     * @param bool $phpLint
+     * @param PhpMdResponse $pmdResponse
+     * @param PhpCsResponse $phpCsResponse
+     * @param PhpCsFixerResponse $phpCsFixerResponse
+     * @param PhpUnitResponse $phpUnitResponse
      * @param PhpUnitStrictCoverageResponse $phpUnitStrictCoverageResponse
-     * @param PhpUnitGuardCoverageResponse  $phpUnitGuardCoverageResponse
+     * @param PhpUnitGuardCoverageResponse $phpUnitGuardCoverageResponse
      *
      * @return PreCommitResponse
      */
@@ -37,6 +38,7 @@ class PreCommitResponseStub
         $preCommit,
         $rightMessage,
         $errorMessage,
+        $enableFaces,
         $composer,
         $jsonLint,
         $phpLint,
@@ -51,6 +53,7 @@ class PreCommitResponseStub
             $preCommit,
             $rightMessage,
             $errorMessage,
+            $enableFaces,
             $composer,
             $jsonLint,
             $phpLint,
@@ -74,6 +77,7 @@ class PreCommitResponseStub
             $bool,
             static::GOOD_JOB,
             static::FIX_YOUR_CODE,
+            $bool,
             $bool,
             $bool,
             $bool,

--- a/src/PhpGitHooks/Module/Configuration/Tests/Stub/PreCommitStub.php
+++ b/src/PhpGitHooks/Module/Configuration/Tests/Stub/PreCommitStub.php
@@ -89,7 +89,11 @@ class PreCommitStub implements RandomStubInterface
                 PhpUnitStrictCoverageStub::createEnabled(),
                 PhpUnitGuardCoverageStub::createEnabled('fix')
             ),
-            MessagesStub::create(MessageStub::create('ok'), MessageStub::create('fix'))
+            MessagesStub::create(
+                MessageStub::create('ok'),
+                MessageStub::create('fix'),
+                EnabledStub::create(true)
+            )
         );
     }
 }

--- a/src/PhpGitHooks/Module/Configuration/Tests/Stub/PrePushResponseStub.php
+++ b/src/PhpGitHooks/Module/Configuration/Tests/Stub/PrePushResponseStub.php
@@ -13,12 +13,13 @@ class PrePushResponseStub
     const ERROR_MESSAGE = 'BAD PUSH';
 
     /**
-     * @param $prePush
-     * @param $rightMessage
-     * @param $errorMessage
-     * @param PhpUnitResponse               $phpUnitResponse
+     * @param bool $prePush
+     * @param string $rightMessage
+     * @param string $errorMessage
+     * @param bool $enableFaces
+     * @param PhpUnitResponse $phpUnitResponse
      * @param PhpUnitStrictCoverageResponse $phpUnitStrictCoverageResponse
-     * @param PhpUnitGuardCoverageResponse  $phpUnitGuardCoverageResponse
+     * @param PhpUnitGuardCoverageResponse $phpUnitGuardCoverageResponse
      *
      * @return PrePushResponse
      */
@@ -26,6 +27,7 @@ class PrePushResponseStub
         $prePush,
         $rightMessage,
         $errorMessage,
+        $enableFaces,
         PhpUnitResponse $phpUnitResponse,
         PhpUnitStrictCoverageResponse $phpUnitStrictCoverageResponse,
         PhpUnitGuardCoverageResponse $phpUnitGuardCoverageResponse
@@ -34,6 +36,7 @@ class PrePushResponseStub
             $prePush,
             $rightMessage,
             $errorMessage,
+            $enableFaces,
             $phpUnitResponse,
             $phpUnitStrictCoverageResponse,
             $phpUnitGuardCoverageResponse
@@ -49,6 +52,7 @@ class PrePushResponseStub
             true,
             self::RIGHT_MESSAGE,
             self::ERROR_MESSAGE,
+            true,
             PhpUnitResponseStub::createEnabled(),
             PhpUnitStrictCoverageResponseStub::createEnabled(),
             PhpUnitGuardCoverageResponseStub::createEnabled()

--- a/src/PhpGitHooks/Module/Configuration/Tests/Stub/PrePushStub.php
+++ b/src/PhpGitHooks/Module/Configuration/Tests/Stub/PrePushStub.php
@@ -55,7 +55,11 @@ class PrePushStub implements RandomStubInterface
             new Undefined(false),
             EnabledStub::create(true),
             PrePushExecuteStub::createEnabled(),
-            MessagesStub::create(MessageStub::create('0k'), MessageStub::create('Faltal'))
+            MessagesStub::create(
+                MessageStub::create('0k'),
+                MessageStub::create('Faltal'),
+                EnabledStub::create(true)
+            )
         );
     }
 

--- a/src/PhpGitHooks/Module/Git/Contract/Command/PreCommitToolHandler.php
+++ b/src/PhpGitHooks/Module/Git/Contract/Command/PreCommitToolHandler.php
@@ -84,9 +84,7 @@ class PreCommitToolHandler implements CommandHandlerInterface
             return;
         }
 
-        /**
-         * @var ConfigurationDataResponse
-         */
+        /** @var ConfigurationDataResponse $configurationData */
         $configurationData = $this->queryBus->handle(new ConfigurationDataFinder());
         $preCommit = $configurationData->getPreCommit();
 
@@ -94,7 +92,9 @@ class PreCommitToolHandler implements CommandHandlerInterface
             $this->executeTools($preCommit, $committedFiles);
         }
 
-        $this->output->writeln(GoodJobLogoResponse::paint($preCommit->getRightMessage()));
+        $this->output->writeln(
+            GoodJobLogoResponse::paint($preCommit->getRightMessage(), $preCommit->isEnableFaces())
+        );
     }
 
     /**
@@ -105,13 +105,21 @@ class PreCommitToolHandler implements CommandHandlerInterface
     {
         if (true === $preCommitResponse->isComposer()) {
             $this->commandBus->handle(
-                new ComposerTool($committedFiles, $preCommitResponse->getErrorMessage())
+                new ComposerTool(
+                    $committedFiles,
+                    $preCommitResponse->getErrorMessage(),
+                    $preCommitResponse->isEnableFaces()
+                )
             );
         }
 
         if (true === $preCommitResponse->isJsonLint()) {
             $this->commandBus->handle(
-                new JsonLintTool($committedFiles, $preCommitResponse->getErrorMessage())
+                new JsonLintTool(
+                    $committedFiles,
+                    $preCommitResponse->getErrorMessage(),
+                    $preCommitResponse->isEnableFaces()
+                )
             );
         }
 
@@ -120,7 +128,11 @@ class PreCommitToolHandler implements CommandHandlerInterface
         if ($phpFiles) {
             if (true === $preCommitResponse->isPhpLint()) {
                 $this->commandBus->handle(
-                    new PhpLintTool($phpFiles, $preCommitResponse->getErrorMessage())
+                    new PhpLintTool(
+                        $phpFiles,
+                        $preCommitResponse->getErrorMessage(),
+                        $preCommitResponse->isEnableFaces()
+                    )
                 );
             }
 
@@ -132,6 +144,7 @@ class PreCommitToolHandler implements CommandHandlerInterface
                         $phpFiles,
                         $phpCsResponse->getPhpCsStandard(),
                         $preCommitResponse->getErrorMessage(),
+                        $preCommitResponse->isEnableFaces(),
                         $phpCsResponse->getIgnore()
                     )
                 );
@@ -148,7 +161,8 @@ class PreCommitToolHandler implements CommandHandlerInterface
                         $phpCsFixerResponse->isPhpCsFixerPsr2(),
                         $phpCsFixerResponse->isPhpCsFixerSymfony(),
                         $phpCsFixerResponse->getPhpCsFixerOptions(),
-                        $preCommitResponse->getErrorMessage()
+                        $preCommitResponse->getErrorMessage(),
+                        $preCommitResponse->isEnableFaces()
                     )
                 );
             }
@@ -160,7 +174,8 @@ class PreCommitToolHandler implements CommandHandlerInterface
                     new PhpMdTool(
                         $phpFiles,
                         $phpMdResponse->getPhpMdOptions(),
-                        $preCommitResponse->getErrorMessage()
+                        $preCommitResponse->getErrorMessage(),
+                        $preCommitResponse->isEnableFaces()
                     )
                 );
             }
@@ -172,7 +187,8 @@ class PreCommitToolHandler implements CommandHandlerInterface
                     new PhpUnitTool(
                         $phpunitResponse->isPhpunitRandomMode(),
                         $phpunitResponse->getPhpunitOptions(),
-                        $preCommitResponse->getErrorMessage()
+                        $preCommitResponse->getErrorMessage(),
+                        $preCommitResponse->isEnableFaces()
                     )
                 );
 
@@ -182,7 +198,8 @@ class PreCommitToolHandler implements CommandHandlerInterface
                     $this->commandBus->handle(
                         new StrictCoverage(
                             $phpunitStrictCoverageResponse->getMinimum(),
-                            $preCommitResponse->getErrorMessage()
+                            $preCommitResponse->getErrorMessage(),
+                            $preCommitResponse->isEnableFaces()
                         )
                     );
                 }

--- a/src/PhpGitHooks/Module/Git/Contract/Response/BadJobLogoResponse.php
+++ b/src/PhpGitHooks/Module/Git/Contract/Response/BadJobLogoResponse.php
@@ -6,12 +6,13 @@ final class BadJobLogoResponse
 {
     /**
      * @param string $message
+     * @param bool $enableFace
      *
      * @return string
      */
-    public static function paint($message)
+    public static function paint($message, $enableFace)
     {
-        return sprintf("<fg=red;options=bold;>
+        $face = $enableFace ? "<fg=red;options=bold;>
                 @@@@@@@@@@@@@@@
              @@@@@@@@@@@@@@@@@@@@
            @@@@@@@@  @@@@@  @@@@@@@
@@ -27,7 +28,11 @@ final class BadJobLogoResponse
            @@@@@@@@@@@@@@@@@@@@@@@@@
              @@@@@@@@@@@@@@@@@@@@@
                 @@@@@@@@@@@@@@@
-        </fg=red;options=bold;>\n
-        <fg=white;bg=red;options=bold;>   %s    </fg=white;bg=red;options=bold;>\n", $message);
+        </fg=red;options=bold;>\n" : '';
+
+        return sprintf(
+            "$face<fg=white;bg=red;options=bold;>   %s    </fg=white;bg=red;options=bold;>\n",
+            $message
+        );
     }
 }

--- a/src/PhpGitHooks/Module/Git/Contract/Response/GoodJobLogoResponse.php
+++ b/src/PhpGitHooks/Module/Git/Contract/Response/GoodJobLogoResponse.php
@@ -6,12 +6,13 @@ final class GoodJobLogoResponse
 {
     /**
      * @param string $message
+     * @param bool $enableFace
      *
      * @return string
      */
-    public static function paint($message)
+    public static function paint($message, $enableFace)
     {
-        return sprintf("<fg=yellow;options=bold;>
+        $face = $enableFace ? "<fg=yellow;options=bold;>
                  @@@@@@@@@@@@@@@
      @@@@      @@@@@@@@@@@@@@@@@@@
     @    @   @@@@@@@@@@@@@@@@@@@@@@@
@@ -28,7 +29,11 @@ final class GoodJobLogoResponse
  @@         @ @@@@@@@@@@@@@@@@@@@@@@
   @@@@@@@@@@   @@@@@@@@@@@@@@@@@@@
                  @@@@@@@@@@@@@@@
-        </fg=yellow;options=bold;>\n
-        <fg=white;bg=yellow;options=bold;>       %s       </fg=white;bg=yellow;options=bold;>", $message);
+        </fg=yellow;options=bold;>\n" : '';
+
+        return sprintf(
+            "$face<fg=white;bg=yellow;options=bold;>       %s       </fg=white;bg=yellow;options=bold;>",
+            $message
+        );
     }
 }

--- a/src/PhpGitHooks/Module/Git/Tests/Behaviour/PreCommitToolHandlerTest.php
+++ b/src/PhpGitHooks/Module/Git/Tests/Behaviour/PreCommitToolHandlerTest.php
@@ -65,23 +65,36 @@ class PreCommitToolHandlerTest extends GitUnitTestCase
         $this->shouldGetFilesCommitted($files);
         $this->shouldHandleQuery(new ConfigurationDataFinder(), $configurationDataResponse);
         $this->shouldHandleCommand(
-            new ComposerTool($files, $configurationDataResponse->getPreCommit()->getErrorMessage())
+            new ComposerTool(
+                $files,
+                $configurationDataResponse->getPreCommit()->getErrorMessage(),
+                $configurationDataResponse->getPreCommit()->isEnableFaces()
+            )
         );
         $this->shouldHandleCommand(
-            new JsonLintTool($files, $configurationDataResponse->getPreCommit()->getErrorMessage())
+            new JsonLintTool(
+                $files,
+                $configurationDataResponse->getPreCommit()->getErrorMessage(),
+                $configurationDataResponse->getPreCommit()->isEnableFaces()
+            )
         );
         $this->shouldHandleQuery(
             new PhpFilesExtractor($files),
             PhpFilesResponseStub::create(FilesCommittedStub::createWithoutPhpFiles())
         );
         $this->shouldHandleCommand(
-            new PhpLintTool($files, $configurationDataResponse->getPreCommit()->getErrorMessage())
+            new PhpLintTool(
+                $files,
+                $configurationDataResponse->getPreCommit()->getErrorMessage(),
+                $configurationDataResponse->getPreCommit()->isEnableFaces()
+            )
         );
         $this->shouldHandleCommand(
             new PhpCsTool(
                 $files,
                 $configurationDataResponse->getPreCommit()->getPhpCs()->getPhpCsStandard(),
                 HookQuestions::PRE_COMMIT_ERROR_MESSAGE_DEFAULT,
+                $configurationDataResponse->getPreCommit()->isEnableFaces(),
                 $configurationDataResponse->getPreCommit()->getPhpCs()->getIgnore()
             )
         );
@@ -93,28 +106,32 @@ class PreCommitToolHandlerTest extends GitUnitTestCase
                 $configurationDataResponse->getPreCommit()->getPhpCsFixer()->isPhpCsFixerPsr2(),
                 $configurationDataResponse->getPreCommit()->getPhpCsFixer()->isPhpCsFixerSymfony(),
                 $configurationDataResponse->getPreCommit()->getPhpCsFixer()->getPhpCsFixerOptions(),
-                $configurationDataResponse->getPreCommit()->getErrorMessage()
+                $configurationDataResponse->getPreCommit()->getErrorMessage(),
+                $configurationDataResponse->getPreCommit()->isEnableFaces()
             )
         );
         $this->shouldHandleCommand(
             new PhpMdTool(
                 $files,
                 $configurationDataResponse->getPreCommit()->getPhpMd()->getPhpMdOptions(),
-                $configurationDataResponse->getPreCommit()->getErrorMessage()
+                $configurationDataResponse->getPreCommit()->getErrorMessage(),
+                $configurationDataResponse->getPreCommit()->isEnableFaces()
             )
         );
         $this->shouldHandleCommand(
             new PhpUnitTool(
                 $configurationDataResponse->getPreCommit()->getPhpUnit()->isPhpunitRandomMode(),
                 $configurationDataResponse->getPreCommit()->getPhpUnit()->getPhpunitOptions(),
-                $configurationDataResponse->getPreCommit()->getErrorMessage()
+                $configurationDataResponse->getPreCommit()->getErrorMessage(),
+                $configurationDataResponse->getPreCommit()->isEnableFaces()
             )
         );
 
         $this->shouldHandleCommand(
             new StrictCoverage(
                 $configurationDataResponse->getPreCommit()->getPhpUnitStrictCoverage()->getMinimum(),
-                $configurationDataResponse->getPreCommit()->getErrorMessage()
+                $configurationDataResponse->getPreCommit()->getErrorMessage(),
+                $configurationDataResponse->getPreCommit()->isEnableFaces()
             )
         );
 
@@ -125,7 +142,10 @@ class PreCommitToolHandlerTest extends GitUnitTestCase
         );
 
         $this->shouldWriteLnOutput(
-            GoodJobLogoResponse::paint($configurationDataResponse->getPreCommit()->getRightMessage())
+            GoodJobLogoResponse::paint(
+                $configurationDataResponse->getPreCommit()->getRightMessage(),
+                $configurationDataResponse->getPreCommit()->isEnableFaces()
+            )
         );
 
         $this->preCommitToolCommandHandler->handle(new PreCommitTool());

--- a/src/PhpGitHooks/Module/Git/Tests/Behaviour/PrePushToolHandlerTest.php
+++ b/src/PhpGitHooks/Module/Git/Tests/Behaviour/PrePushToolHandlerTest.php
@@ -35,6 +35,7 @@ class PrePushToolHandlerTest extends GitUnitTestCase
 
     /**
      * @test
+     * @throws InvalidPushException
      */
     public function itShouldNotExecuteHook()
     {
@@ -48,6 +49,7 @@ class PrePushToolHandlerTest extends GitUnitTestCase
 
     /**
      * @test
+     * @throws InvalidPushException
      */
     public function itShouldThrowsExceptionFromOriginalScript()
     {
@@ -62,7 +64,10 @@ class PrePushToolHandlerTest extends GitUnitTestCase
         $this->shouldWriteLnOutput(PrePushToolHandler::PRE_PUSH_HOOK);
         $this->shouldExecutePrePushOriginal($this->remote, $this->url, 'error');
         $this->shouldWriteLnOutput(
-            BadJobLogoResponse::paint($configurationDataResponse->getPrePush()->getErrorMessage())
+            BadJobLogoResponse::paint(
+                $configurationDataResponse->getPrePush()->getErrorMessage(),
+                $configurationDataResponse->getPrePush()->isEnableFaces()
+            )
         );
 
         $this->prePushToolCommandHandler->handle(new PrePushTool($this->remote, $this->url));
@@ -70,6 +75,7 @@ class PrePushToolHandlerTest extends GitUnitTestCase
 
     /**
      * @test
+     * @throws InvalidPushException
      */
     public function itShouldWorksFine()
     {
@@ -85,13 +91,15 @@ class PrePushToolHandlerTest extends GitUnitTestCase
             new PhpUnitTool(
                 $configurationDataResponse->getPrePush()->getPhpUnit()->isPhpunitRandomMode(),
                 $configurationDataResponse->getPrePush()->getPhpUnit()->getPhpunitOptions(),
-                $configurationDataResponse->getPrePush()->getErrorMessage()
+                $configurationDataResponse->getPrePush()->getErrorMessage(),
+                $configurationDataResponse->getPrePush()->isEnableFaces()
             )
         );
         $this->shouldHandleCommand(
             new StrictCoverage(
                 $configurationDataResponse->getPrePush()->getPhpUnitStrictCoverage()->getMinimum(),
-                $configurationDataResponse->getPrePush()->getErrorMessage()
+                $configurationDataResponse->getPrePush()->getErrorMessage(),
+                $configurationDataResponse->getPrePush()->isEnableFaces()
             )
         );
 
@@ -102,7 +110,10 @@ class PrePushToolHandlerTest extends GitUnitTestCase
         );
 
         $this->shouldWriteLnOutput(
-            GoodJobLogoResponse::paint($configurationDataResponse->getPrePush()->getRightMessage())
+            GoodJobLogoResponse::paint(
+                $configurationDataResponse->getPrePush()->getRightMessage(),
+                $configurationDataResponse->getPrePush()->isEnableFaces()
+            )
         );
 
         $this->prePushToolCommandHandler->handle(new PrePushTool($this->remote, $this->url));

--- a/src/PhpGitHooks/Module/JsonLint/Contract/Command/JsonLintTool.php
+++ b/src/PhpGitHooks/Module/JsonLint/Contract/Command/JsonLintTool.php
@@ -14,17 +14,23 @@ class JsonLintTool implements CommandInterface
      * @var string
      */
     private $errorMessage;
+    /**
+     * @var bool
+     */
+    private $enableFaces;
 
     /**
      * JsonLintToolCommand constructor.
      *
-     * @param array  $files
+     * @param array $files
      * @param string $errorMessage
+     * @param bool $enableFaces
      */
-    public function __construct(array $files, $errorMessage)
+    public function __construct(array $files, $errorMessage, $enableFaces)
     {
         $this->files = $files;
         $this->errorMessage = $errorMessage;
+        $this->enableFaces = $enableFaces;
     }
 
     /**
@@ -33,6 +39,14 @@ class JsonLintTool implements CommandInterface
     public function getErrorMessage()
     {
         return $this->errorMessage;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEnableFaces()
+    {
+        return $this->enableFaces;
     }
 
     /**

--- a/src/PhpGitHooks/Module/JsonLint/Contract/Command/JsonLintToolHandler.php
+++ b/src/PhpGitHooks/Module/JsonLint/Contract/Command/JsonLintToolHandler.php
@@ -6,6 +6,7 @@ use Bruli\EventBusBundle\CommandBus\CommandHandlerInterface;
 use Bruli\EventBusBundle\CommandBus\CommandInterface;
 use Bruli\EventBusBundle\QueryBus\QueryBus;
 use PhpGitHooks\Module\Files\Contract\Query\JsonFilesExtractor;
+use PhpGitHooks\Module\JsonLint\Contract\Exception\JsonLintViolationsException;
 use PhpGitHooks\Module\JsonLint\Service\JsonLintToolExecutor;
 
 class JsonLintToolHandler implements CommandHandlerInterface
@@ -34,15 +35,18 @@ class JsonLintToolHandler implements CommandHandlerInterface
     }
 
     /**
-     * @param array  $files
+     * @param array $files
      * @param string $errorMessage
+     * @param bool $enableFaces
+     *
+     * @throws JsonLintViolationsException
      */
-    private function execute(array $files, $errorMessage)
+    private function execute(array $files, $errorMessage, $enableFaces)
     {
         $jsonFilesResponse = $this->queryBus->handle(new JsonFilesExtractor($files));
 
         if (true === $this->jsonFilesExists($jsonFilesResponse->getFiles())) {
-            $this->jsonLintToolExecutor->execute($jsonFilesResponse->getFiles(), $errorMessage);
+            $this->jsonLintToolExecutor->execute($jsonFilesResponse->getFiles(), $errorMessage, $enableFaces);
         }
     }
 
@@ -58,9 +62,11 @@ class JsonLintToolHandler implements CommandHandlerInterface
 
     /**
      * @param CommandInterface|JsonLintTool $command
+     *
+     * @throws JsonLintViolationsException
      */
     public function handle(CommandInterface $command)
     {
-        $this->execute($command->getFiles(), $command->getErrorMessage());
+        $this->execute($command->getFiles(), $command->getErrorMessage(), $command->isEnableFaces());
     }
 }

--- a/src/PhpGitHooks/Module/JsonLint/Infrastructure/Tool/JsonLintProcessor.php
+++ b/src/PhpGitHooks/Module/JsonLint/Infrastructure/Tool/JsonLintProcessor.php
@@ -65,5 +65,7 @@ class JsonLintProcessor implements JsonLintProcessorInterface
         if (false === $process->isSuccessful()) {
             return $process->getErrorOutput();
         }
+
+        return null;
     }
 }

--- a/src/PhpGitHooks/Module/JsonLint/Service/JsonLintToolExecutor.php
+++ b/src/PhpGitHooks/Module/JsonLint/Service/JsonLintToolExecutor.php
@@ -33,12 +33,13 @@ class JsonLintToolExecutor
     }
 
     /**
-     * @param array  $files
+     * @param array $files
      * @param string $errorMessage
+     * @param bool $enableFaces
      *
      * @throws JsonLintViolationsException
      */
-    public function execute(array $files, $errorMessage)
+    public function execute(array $files, $errorMessage, $enableFaces)
     {
         $outputMessage = new PreCommitOutputWriter(self::CHECKING_MESSAGE);
         $this->output->write($outputMessage->getMessage());
@@ -53,7 +54,7 @@ class JsonLintToolExecutor
         if (!empty($errors)) {
             $this->output->writeln($outputMessage->getFailMessage());
             $this->output->writeln($outputMessage->setError(implode('', $errors)));
-            $this->output->writeln(BadJobLogoResponse::paint($errorMessage));
+            $this->output->writeln(BadJobLogoResponse::paint($errorMessage, $enableFaces));
             throw new JsonLintViolationsException(implode('', $errors));
         }
 

--- a/src/PhpGitHooks/Module/JsonLint/Tests/Behaviour/JsonLintToolHandlerTest.php
+++ b/src/PhpGitHooks/Module/JsonLint/Tests/Behaviour/JsonLintToolHandlerTest.php
@@ -40,6 +40,7 @@ class JsonLintToolHandlerTest extends JsonLintUnitTestCase
 
     /**
      * @test
+     * @throws JsonLintViolationsException
      */
     public function itShouldNotExecuteTool()
     {
@@ -51,12 +52,13 @@ class JsonLintToolHandlerTest extends JsonLintUnitTestCase
         );
 
         $this->jsonLintToolCommandHandler->handle(
-            new JsonLintTool($files, $this->errorMessage)
+            new JsonLintTool($files, $this->errorMessage, true)
         );
     }
 
     /**
      * @test
+     * @throws JsonLintViolationsException
      */
     public function itShouldExecuteTool()
     {
@@ -76,12 +78,13 @@ class JsonLintToolHandlerTest extends JsonLintUnitTestCase
         $this->shouldWriteLnOutput($output->getSuccessfulMessage());
 
         $this->jsonLintToolCommandHandler->handle(
-            new JsonLintTool($files->getFiles(), $this->errorMessage)
+            new JsonLintTool($files->getFiles(), $this->errorMessage, true)
         );
     }
 
     /**
      * @test
+     * @throws JsonLintViolationsException
      */
     public function itShouldThrowsException()
     {
@@ -105,10 +108,10 @@ class JsonLintToolHandlerTest extends JsonLintUnitTestCase
 
         $this->shouldWriteLnOutput($output->getFailMessage());
         $this->shouldWriteLnOutput($output->setError($errorTxt));
-        $this->shouldWriteLnOutput(BadJobLogoResponse::paint($this->errorMessage));
+        $this->shouldWriteLnOutput(BadJobLogoResponse::paint($this->errorMessage, true));
 
         $this->jsonLintToolCommandHandler->handle(
-            new JsonLintTool($jsonFilesResponse->getFiles(), $this->errorMessage)
+            new JsonLintTool($jsonFilesResponse->getFiles(), $this->errorMessage, true)
         );
     }
 }

--- a/src/PhpGitHooks/Module/PhpCs/Contract/Command/PhpCsTool.php
+++ b/src/PhpGitHooks/Module/PhpCs/Contract/Command/PhpCsTool.php
@@ -21,21 +21,27 @@ class PhpCsTool implements CommandInterface
     /**
      * @var string
      */
+    private $enableFaces;
+    /**
+     * @var string
+     */
     private $ignore;
 
     /**
      * PhpCsToolCommand constructor.
      *
-     * @param array  $files
+     * @param array $files
      * @param string $standard
      * @param string $errorMessage
+     * @param bool $enableFaces
      * @param string $ignore
      */
-    public function __construct(array $files, $standard, $errorMessage, $ignore)
+    public function __construct(array $files, $standard, $errorMessage, $enableFaces, $ignore)
     {
         $this->files = $files;
         $this->standard = $standard;
         $this->errorMessage = $errorMessage;
+        $this->enableFaces = $enableFaces;
         $this->ignore = $ignore;
     }
 
@@ -45,6 +51,14 @@ class PhpCsTool implements CommandInterface
     public function getErrorMessage()
     {
         return $this->errorMessage;
+    }
+
+    /**
+     * @return string
+     */
+    public function isEnableFaces()
+    {
+        return $this->enableFaces;
     }
 
     /**

--- a/src/PhpGitHooks/Module/PhpCs/Contract/Command/PhpCsToolHandler.php
+++ b/src/PhpGitHooks/Module/PhpCs/Contract/Command/PhpCsToolHandler.php
@@ -38,11 +38,12 @@ class PhpCsToolHandler implements CommandHandlerInterface
      * @param array $files
      * @param string $standard
      * @param string $errorMessage
+     * @param bool $enableFace
      * @param string $ignore
      *
      * @throws PhpCsViolationException
      */
-    private function execute(array $files, $standard, $errorMessage, $ignore)
+    private function execute(array $files, $standard, $errorMessage, $enableFace, $ignore)
     {
         $outputMessage = new PreCommitOutputWriter(self::EXECUTE_MESSAGE);
         $this->output->write($outputMessage->getMessage());
@@ -57,7 +58,7 @@ class PhpCsToolHandler implements CommandHandlerInterface
         if (!empty($errors)) {
             $this->output->writeln($outputMessage->getFailMessage());
             $this->output->writeln($outputMessage->setError(implode('', $errors)));
-            $this->output->writeln(BadJobLogoResponse::paint($errorMessage));
+            $this->output->writeln(BadJobLogoResponse::paint($errorMessage, $enableFace));
             throw new PhpCsViolationException();
         }
         $this->output->writeln($outputMessage->getSuccessfulMessage());
@@ -73,6 +74,7 @@ class PhpCsToolHandler implements CommandHandlerInterface
             $command->getFiles(),
             $command->getStandard(),
             $command->getErrorMessage(),
+            $command->isEnableFaces(),
             $command->getIgnore()
         );
     }

--- a/src/PhpGitHooks/Module/PhpCs/Tests/Behaviour/PhpCsToolHandlerTest.php
+++ b/src/PhpGitHooks/Module/PhpCs/Tests/Behaviour/PhpCsToolHandlerTest.php
@@ -28,6 +28,7 @@ class PhpCsToolHandlerTest extends PhpCsUnitTestCase
 
     /**
      * @test
+     * @throws PhpCsViolationException
      */
     public function itShouldThrowsException()
     {
@@ -47,13 +48,16 @@ class PhpCsToolHandlerTest extends PhpCsUnitTestCase
 
         $this->shouldWriteLnOutput($output->getFailMessage());
         $this->shouldWriteLnOutput($output->setError($errorTxt));
-        $this->shouldWriteLnOutput(BadJobLogoResponse::paint(HookQuestions::PRE_COMMIT_ERROR_MESSAGE_DEFAULT));
+        $this->shouldWriteLnOutput(
+            BadJobLogoResponse::paint(HookQuestions::PRE_COMMIT_ERROR_MESSAGE_DEFAULT, true)
+        );
 
         $this->phpCsToolCommandHandler->handle(
             new PhpCsTool(
                 $files,
                 'PSR2',
                 HookQuestions::PRE_COMMIT_ERROR_MESSAGE_DEFAULT,
+                true,
                 ''
             )
         );
@@ -61,6 +65,7 @@ class PhpCsToolHandlerTest extends PhpCsUnitTestCase
 
     /**
      * @test
+     * @throws PhpCsViolationException
      */
     public function itShouldWorksFine()
     {
@@ -80,6 +85,7 @@ class PhpCsToolHandlerTest extends PhpCsUnitTestCase
                 $files,
                 'PSR2',
                 HookQuestions::PRE_COMMIT_ERROR_MESSAGE_DEFAULT,
+                true,
                 ''
             )
         );

--- a/src/PhpGitHooks/Module/PhpCsFixer/Contract/Command/PhpCsFixerTool.php
+++ b/src/PhpGitHooks/Module/PhpCsFixer/Contract/Command/PhpCsFixerTool.php
@@ -34,19 +34,24 @@ class PhpCsFixerTool implements CommandInterface
      * @var string
      */
     private $errorMessage;
+    /**
+     * @var bool
+     */
+    private $enableFaces;
 
     /**
      * PhpCsFixerToolCommand constructor.
      *
-     * @param array  $files
-     * @param bool   $psr0
-     * @param bool   $psr1
-     * @param bool   $psr2
-     * @param bool   $symfony
+     * @param array $files
+     * @param bool $psr0
+     * @param bool $psr1
+     * @param bool $psr2
+     * @param bool $symfony
      * @param string $options
      * @param string $errorMessage
+     * @param bool $enableFaces
      */
-    public function __construct(array $files, $psr0, $psr1, $psr2, $symfony, $options, $errorMessage)
+    public function __construct(array $files, $psr0, $psr1, $psr2, $symfony, $options, $errorMessage, $enableFaces)
     {
         $this->files = $files;
         $this->psr0 = $psr0;
@@ -55,6 +60,7 @@ class PhpCsFixerTool implements CommandInterface
         $this->symfony = $symfony;
         $this->options = $options;
         $this->errorMessage = $errorMessage;
+        $this->enableFaces = $enableFaces;
     }
 
     /**
@@ -111,5 +117,13 @@ class PhpCsFixerTool implements CommandInterface
     public function getErrorMessage()
     {
         return $this->errorMessage;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEnableFaces()
+    {
+        return $this->enableFaces;
     }
 }

--- a/src/PhpGitHooks/Module/PhpCsFixer/Contract/Command/PhpCsFixerToolHandler.php
+++ b/src/PhpGitHooks/Module/PhpCsFixer/Contract/Command/PhpCsFixerToolHandler.php
@@ -41,23 +41,26 @@ class PhpCsFixerToolHandler implements CommandHandlerInterface
      * @param bool $symfony
      * @param string $options
      * @param string $errorMessage
+     * @param bool $enableFaces
+     *
+     * @throws PhpCsFixerViolationsException
      */
-    private function execute(array $files, $psr0, $psr1, $psr2, $symfony, $options, $errorMessage)
+    private function execute(array $files, $psr0, $psr1, $psr2, $symfony, $options, $errorMessage, $enableFaces)
     {
         if (true === $psr0) {
-            $this->executeTool($files, '@PSR0', $options, $errorMessage);
+            $this->executeTool($files, '@PSR0', $options, $errorMessage, $enableFaces);
         }
 
         if (true === $psr1) {
-            $this->executeTool($files, '@PSR1', $options, $errorMessage);
+            $this->executeTool($files, '@PSR1', $options, $errorMessage, $enableFaces);
         }
 
         if (true === $psr2) {
-            $this->executeTool($files, '@PSR2', $options, $errorMessage);
+            $this->executeTool($files, '@PSR2', $options, $errorMessage, $enableFaces);
         }
 
         if (true === $symfony) {
-            $this->executeTool($files, '@Symfony', $options, $errorMessage);
+            $this->executeTool($files, '@Symfony', $options, $errorMessage, $enableFaces);
         }
     }
 
@@ -66,10 +69,11 @@ class PhpCsFixerToolHandler implements CommandHandlerInterface
      * @param string $level
      * @param string $options
      * @param string $errorMessage
+     * @param bool $enableFaces
      *
      * @throws PhpCsFixerViolationsException
      */
-    private function executeTool(array $files, $level, $options, $errorMessage)
+    private function executeTool(array $files, $level, $options, $errorMessage, $enableFaces)
     {
         $outputMessage = new PreCommitOutputWriter(
             sprintf('Checking %s code style with PHP-CS-FIXER', str_replace('@', '', $level))
@@ -87,7 +91,7 @@ class PhpCsFixerToolHandler implements CommandHandlerInterface
             $this->output->writeln($outputMessage->getFailMessage());
             $errorsText = $outputMessage->setError(implode('', $errors));
             $this->output->writeln($errorsText);
-            $this->output->writeln(BadJobLogoResponse::paint($errorMessage));
+            $this->output->writeln(BadJobLogoResponse::paint($errorMessage, $enableFaces));
             throw  new PhpCsFixerViolationsException();
         }
 
@@ -96,6 +100,8 @@ class PhpCsFixerToolHandler implements CommandHandlerInterface
 
     /**
      * @param CommandInterface|PhpCsFixerTool $command
+     *
+     * @throws PhpCsFixerViolationsException
      */
     public function handle(CommandInterface $command)
     {
@@ -106,7 +112,8 @@ class PhpCsFixerToolHandler implements CommandHandlerInterface
             $command->isPsr2(),
             $command->isSymfony(),
             $command->getOptions(),
-            $command->getErrorMessage()
+            $command->getErrorMessage(),
+            $command->isEnableFaces()
         );
     }
 }

--- a/src/PhpGitHooks/Module/PhpCsFixer/Infrastructure/Tool/PhpCsFixerToolProcessor.php
+++ b/src/PhpGitHooks/Module/PhpCsFixer/Infrastructure/Tool/PhpCsFixerToolProcessor.php
@@ -76,5 +76,7 @@ class PhpCsFixerToolProcessor implements PhpCsFixerToolProcessorInterface
         if (false === $process->isSuccessful()) {
             return $process->getErrorOutput();
         }
+
+        return null;
     }
 }

--- a/src/PhpGitHooks/Module/PhpCsFixer/Tests/Behaviour/PhpCsFixerToolHandlerTest.php
+++ b/src/PhpGitHooks/Module/PhpCsFixer/Tests/Behaviour/PhpCsFixerToolHandlerTest.php
@@ -50,7 +50,12 @@ class PhpCsFixerToolHandlerTest extends PhpCsFixerUnitTestCase
 
         $this->shouldWriteLnOutput($outputMessage->getFailMessage());
         $this->shouldWriteLnOutput($outputMessage->setError($errors));
-        $this->shouldWriteLnOutput(BadJobLogoResponse::paint($configurationData->getPreCommit()->getErrorMessage()));
+        $this->shouldWriteLnOutput(
+            BadJobLogoResponse::paint(
+                $configurationData->getPreCommit()->getErrorMessage(),
+                $configurationData->getPreCommit()->isEnableFaces()
+            )
+        );
 
         $this->phpCsFixerToolCommandHandler->handle(
             new PhpCsFixerTool(
@@ -60,7 +65,8 @@ class PhpCsFixerToolHandlerTest extends PhpCsFixerUnitTestCase
                 $configurationData->getPreCommit()->getPhpCsFixer()->isPhpCsFixerPsr2(),
                 $configurationData->getPreCommit()->getPhpCsFixer()->isPhpCsFixerSymfony(),
                 $phpCsFixerOptions->value(),
-                $configurationData->getPreCommit()->getErrorMessage()
+                $configurationData->getPreCommit()->getErrorMessage(),
+                $configurationData->getPreCommit()->isEnableFaces()
             )
         );
     }
@@ -118,7 +124,8 @@ class PhpCsFixerToolHandlerTest extends PhpCsFixerUnitTestCase
                 $configurationData->getPreCommit()->getPhpCsFixer()->isPhpCsFixerPsr2(),
                 $configurationData->getPreCommit()->getPhpCsFixer()->isPhpCsFixerSymfony(),
                 $phpCsFixerOptions->value(),
-                $configurationData->getPreCommit()->getErrorMessage()
+                $configurationData->getPreCommit()->getErrorMessage(),
+                $configurationData->getPreCommit()->isEnableFaces()
             )
         );
     }

--- a/src/PhpGitHooks/Module/PhpLint/Contract/Command/PhpLintTool.php
+++ b/src/PhpGitHooks/Module/PhpLint/Contract/Command/PhpLintTool.php
@@ -14,17 +14,23 @@ class PhpLintTool implements CommandInterface
      * @var string
      */
     private $errorMessage;
+    /**
+     * @var bool
+     */
+    private $enableFaces;
 
     /**
      * PhpLintToolCommand constructor.
      *
-     * @param array  $files
+     * @param array $files
      * @param string $errorMessage
+     * @param bool $enableFaces
      */
-    public function __construct(array $files, $errorMessage)
+    public function __construct(array $files, $errorMessage, $enableFaces)
     {
         $this->files = $files;
         $this->errorMessage = $errorMessage;
+        $this->enableFaces = $enableFaces;
     }
 
     /**
@@ -41,5 +47,13 @@ class PhpLintTool implements CommandInterface
     public function getErrorMessage()
     {
         return $this->errorMessage;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEnableFaces()
+    {
+        return $this->enableFaces;
     }
 }

--- a/src/PhpGitHooks/Module/PhpLint/Contract/Command/PhpLintToolHandler.php
+++ b/src/PhpGitHooks/Module/PhpLint/Contract/Command/PhpLintToolHandler.php
@@ -37,10 +37,11 @@ class PhpLintToolHandler implements CommandHandlerInterface
     /**
      * @param array $files
      * @param string $errorMessage
+     * @param bool $enableFaces
      *
      * @throws PhpLintViolationsException
      */
-    private function execute(array $files, $errorMessage)
+    private function execute(array $files, $errorMessage, $enableFaces)
     {
         $outputMessage = new PreCommitOutputWriter(self::RUNNING_PHPLINT);
         $this->output->write($outputMessage->getMessage());
@@ -55,7 +56,7 @@ class PhpLintToolHandler implements CommandHandlerInterface
         if (!empty($errors)) {
             $this->output->writeln($outputMessage->getFailMessage());
             $this->output->writeln($outputMessage->setError(implode('', $errors)));
-            $this->output->writeln(BadJobLogoResponse::paint($errorMessage));
+            $this->output->writeln(BadJobLogoResponse::paint($errorMessage, $enableFaces));
 
             throw new PhpLintViolationsException();
         }
@@ -65,9 +66,11 @@ class PhpLintToolHandler implements CommandHandlerInterface
 
     /**
      * @param CommandInterface|PhpLintTool $command
+     *
+     * @throws PhpLintViolationsException
      */
     public function handle(CommandInterface $command)
     {
-        $this->execute($command->getFiles(), $command->getErrorMessage());
+        $this->execute($command->getFiles(), $command->getErrorMessage(), $command->isEnableFaces());
     }
 }

--- a/src/PhpGitHooks/Module/PhpLint/Tests/Behaviour/PhpLintToolHandlerTest.php
+++ b/src/PhpGitHooks/Module/PhpLint/Tests/Behaviour/PhpLintToolHandlerTest.php
@@ -29,6 +29,7 @@ class PhpLintToolHandlerTest extends PhpLintUnitTestCase
 
     /**
      * @test
+     * @throws PhpLintViolationsException
      */
     public function itShouldThrowsException()
     {
@@ -49,15 +50,16 @@ class PhpLintToolHandlerTest extends PhpLintUnitTestCase
 
         $this->shouldWriteLnOutput($outputMessage->getFailMessage());
         $this->shouldWriteLnOutput($outputMessage->setError($errors));
-        $this->shouldWriteLnOutput(BadJobLogoResponse::paint($errorMessage));
+        $this->shouldWriteLnOutput(BadJobLogoResponse::paint($errorMessage, true));
 
         $this->phpLintToolCommandHandler->handle(
-            new PhpLintTool($phpFiles, $errorMessage)
+            new PhpLintTool($phpFiles, $errorMessage, true)
         );
     }
 
     /**
      * @test
+     * @throws PhpLintViolationsException
      */
     public function itShouldWorksFine()
     {
@@ -73,7 +75,7 @@ class PhpLintToolHandlerTest extends PhpLintUnitTestCase
         $this->shouldWriteLnOutput($outputMessage->getSuccessfulMessage());
 
         $this->phpLintToolCommandHandler->handle(
-            new PhpLintTool($phpFiles, HookQuestions::PRE_COMMIT_ERROR_MESSAGE_DEFAULT)
+            new PhpLintTool($phpFiles, HookQuestions::PRE_COMMIT_ERROR_MESSAGE_DEFAULT, true)
         );
     }
 }

--- a/src/PhpGitHooks/Module/PhpMd/Contract/Command/PhpMdTool.php
+++ b/src/PhpGitHooks/Module/PhpMd/Contract/Command/PhpMdTool.php
@@ -15,6 +15,10 @@ class PhpMdTool implements CommandInterface
      */
     private $errorMessage;
     /**
+     * @var bool
+     */
+    private $enableFaces;
+    /**
      * @var string
      */
     private $options;
@@ -22,14 +26,16 @@ class PhpMdTool implements CommandInterface
     /**
      * PhpMdToolCommand constructor.
      *
-     * @param array  $files
+     * @param array $files
      * @param string $options
      * @param string $errorMessage
+     * @param bool $enableFaces
      */
-    public function __construct(array $files, $options, $errorMessage)
+    public function __construct(array $files, $options, $errorMessage, $enableFaces)
     {
         $this->files = $files;
         $this->errorMessage = $errorMessage;
+        $this->enableFaces = $enableFaces;
         $this->options = $options;
     }
 
@@ -47,6 +53,14 @@ class PhpMdTool implements CommandInterface
     public function getErrorMessage()
     {
         return $this->errorMessage;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEnableFaces()
+    {
+        return $this->enableFaces;
     }
 
     /**

--- a/src/PhpGitHooks/Module/PhpMd/Contract/Command/PhpMdToolHandler.php
+++ b/src/PhpGitHooks/Module/PhpMd/Contract/Command/PhpMdToolHandler.php
@@ -35,13 +35,14 @@ class PhpMdToolHandler implements CommandHandlerInterface
     }
 
     /**
-     * @param array  $files
+     * @param array $files
      * @param string $options
      * @param string $errorMessage
+     * @param bool $enableFaces
      *
      * @throws PhpMdViolationsException
      */
-    private function execute(array  $files, $options, $errorMessage)
+    private function execute(array  $files, $options, $errorMessage, $enableFaces)
     {
         $outputMessage = new PreCommitOutputWriter(self::CHECKING_MESSAGE);
         $this->output->write($outputMessage->getMessage());
@@ -57,7 +58,7 @@ class PhpMdToolHandler implements CommandHandlerInterface
             $outputText = $outputMessage->setError(implode('', $errors));
             $this->output->writeln($outputMessage->getFailMessage());
             $this->output->writeln($outputText);
-            $this->output->writeln(BadJobLogoResponse::paint($errorMessage));
+            $this->output->writeln(BadJobLogoResponse::paint($errorMessage, $enableFaces));
             throw new PhpMdViolationsException();
         }
 
@@ -66,9 +67,16 @@ class PhpMdToolHandler implements CommandHandlerInterface
 
     /**
      * @param CommandInterface|PhpMdTool $command
+     *
+     * @throws PhpMdViolationsException
      */
     public function handle(CommandInterface $command)
     {
-        $this->execute($command->getFiles(), $command->getOptions(), $command->getErrorMessage());
+        $this->execute(
+            $command->getFiles(),
+            $command->getOptions(),
+            $command->getErrorMessage(),
+            $command->isEnableFaces()
+        );
     }
 }

--- a/src/PhpGitHooks/Module/PhpMd/Tests/Behaviour/PhpMdToolHandlerTest.php
+++ b/src/PhpGitHooks/Module/PhpMd/Tests/Behaviour/PhpMdToolHandlerTest.php
@@ -29,6 +29,7 @@ class PhpMdToolHandlerTest extends PhpMdUnitTestCase
 
     /**
      * @test
+     * @throws PhpMdViolationsException
      */
     public function itShouldThrowsException()
     {
@@ -50,14 +51,15 @@ class PhpMdToolHandlerTest extends PhpMdUnitTestCase
 
         $this->shouldWriteLnOutput($outputMessage->getFailMessage());
         $this->shouldWriteLnOutput($outputMessage->setError($errorsText));
-        $this->shouldWriteLnOutput(BadJobLogoResponse::paint($errorMessage));
+        $this->shouldWriteLnOutput(BadJobLogoResponse::paint($errorMessage, true));
 
-        $command = new PhpMdTool($phpFiles, $phpMdOptions->value(), $errorMessage);
+        $command = new PhpMdTool($phpFiles, $phpMdOptions->value(), $errorMessage, true);
         $this->phpMdToolCommandHandler->handle($command);
     }
 
     /**
      * @test
+     * @throws PhpMdViolationsException
      */
     public function itShouldWorksFine()
     {
@@ -74,7 +76,7 @@ class PhpMdToolHandlerTest extends PhpMdUnitTestCase
 
         $this->shouldWriteLnOutput($outputMessage->getSuccessfulMessage());
 
-        $command = new PhpMdTool($phpFiles, $phpMdOptions->value(), $errorMessage);
+        $command = new PhpMdTool($phpFiles, $phpMdOptions->value(), $errorMessage, true);
         $this->phpMdToolCommandHandler->handle($command);
     }
 }

--- a/src/PhpGitHooks/Module/PhpUnit/Contract/Command/PhpUnitTool.php
+++ b/src/PhpGitHooks/Module/PhpUnit/Contract/Command/PhpUnitTool.php
@@ -18,19 +18,25 @@ class PhpUnitTool implements CommandInterface
      * @var string
      */
     private $errorMessage;
+    /**
+     * @var bool
+     */
+    private $enableFaces;
 
     /**
      * PhpUnitToolCommand constructor.
      *
-     * @param bool        $randomMode
+     * @param bool $randomMode
      * @param string|null $options
-     * @param string      $errorMessage
+     * @param string $errorMessage
+     * @param bool $enableFaces
      */
-    public function __construct($randomMode, $options, $errorMessage)
+    public function __construct($randomMode, $options, $errorMessage, $enableFaces)
     {
         $this->randomMode = $randomMode;
         $this->options = $options;
         $this->errorMessage = $errorMessage;
+        $this->enableFaces = $enableFaces;
     }
 
     /**
@@ -55,5 +61,13 @@ class PhpUnitTool implements CommandInterface
     public function getErrorMessage()
     {
         return $this->errorMessage;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEnableFaces()
+    {
+        return $this->enableFaces;
     }
 }

--- a/src/PhpGitHooks/Module/PhpUnit/Contract/Command/PhpUnitToolHandler.php
+++ b/src/PhpGitHooks/Module/PhpUnit/Contract/Command/PhpUnitToolHandler.php
@@ -6,7 +6,6 @@ use Bruli\EventBusBundle\CommandBus\CommandHandlerInterface;
 use Bruli\EventBusBundle\CommandBus\CommandInterface;
 use PhpGitHooks\Module\Git\Contract\Response\BadJobLogoResponse;
 use PhpGitHooks\Module\Git\Service\PreCommitOutputWriter;
-use PhpGitHooks\Module\PhpUnit\Contract\Command\PhpUnitTool;
 use PhpGitHooks\Module\PhpUnit\Contract\Exception\PhpUnitViolationException;
 use PhpGitHooks\Module\PhpUnit\Model\PhpUnitProcessorInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -48,10 +47,11 @@ class PhpUnitToolHandler implements CommandHandlerInterface
      * @param string $randomMode
      * @param string $options
      * @param string $errorMessage
+     * @param bool $enableFaces
      *
      * @throws PhpUnitViolationException
      */
-    private function execute($randomMode, $options, $errorMessage)
+    private function execute($randomMode, $options, $errorMessage, $enableFaces)
     {
         $outputMessage = new PreCommitOutputWriter(self::EXECUTING_MESSAGE);
         $this->output->writeln($outputMessage->getMessage());
@@ -59,7 +59,7 @@ class PhpUnitToolHandler implements CommandHandlerInterface
         $testResult = $this->executeTool($randomMode, $options);
 
         if (false === $testResult) {
-            $this->output->writeln(BadJobLogoResponse::paint($errorMessage));
+            $this->output->writeln(BadJobLogoResponse::paint($errorMessage, $enableFaces));
 
             throw new PhpUnitViolationException();
         }
@@ -80,13 +80,16 @@ class PhpUnitToolHandler implements CommandHandlerInterface
 
     /**
      * @param CommandInterface|PhpUnitTool $command
+     *
+     * @throws PhpUnitViolationException
      */
     public function handle(CommandInterface $command)
     {
         $this->execute(
             $command->isRandomMode(),
             $command->getOptions(),
-            $command->getErrorMessage()
+            $command->getErrorMessage(),
+            $command->isEnableFaces()
         );
     }
 }

--- a/src/PhpGitHooks/Module/PhpUnit/Contract/Command/StrictCoverage.php
+++ b/src/PhpGitHooks/Module/PhpUnit/Contract/Command/StrictCoverage.php
@@ -14,17 +14,23 @@ class StrictCoverage implements CommandInterface
      * @var string
      */
     private $errorMessage;
+    /**
+     * @var bool
+     */
+    private $enableFaces;
 
     /**
      * StrictCoverageCommand constructor.
      *
-     * @param float  $minimumCoverage
+     * @param float $minimumCoverage
      * @param string $errorMessage
+     * @param bool $enableFaces
      */
-    public function __construct($minimumCoverage, $errorMessage)
+    public function __construct($minimumCoverage, $errorMessage, $enableFaces)
     {
         $this->minimumCoverage = $minimumCoverage;
         $this->errorMessage = $errorMessage;
+        $this->enableFaces = $enableFaces;
     }
 
     /**
@@ -41,5 +47,13 @@ class StrictCoverage implements CommandInterface
     public function getErrorMessage()
     {
         return $this->errorMessage;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEnableFaces()
+    {
+        return $this->enableFaces;
     }
 }

--- a/src/PhpGitHooks/Module/PhpUnit/Contract/Command/StrictCoverageToolHandler.php
+++ b/src/PhpGitHooks/Module/PhpUnit/Contract/Command/StrictCoverageToolHandler.php
@@ -6,6 +6,7 @@ use Bruli\EventBusBundle\CommandBus\CommandHandlerInterface;
 use Bruli\EventBusBundle\CommandBus\CommandInterface;
 use PhpGitHooks\Module\Configuration\Domain\MinimumStrictCoverage;
 use PhpGitHooks\Module\Git\Service\PreCommitOutputWriter;
+use PhpGitHooks\Module\PhpUnit\Contract\Exception\InvalidStrictCoverageException;
 use PhpGitHooks\Module\PhpUnit\Service\StrictCoverageTool;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -35,12 +36,15 @@ class StrictCoverageToolHandler implements CommandHandlerInterface
     /**
      * @param MinimumStrictCoverage $minimumStrictCoverage
      * @param string $errorMessage
+     * @param bool $enableFaces
+     *
+     * @throws InvalidStrictCoverageException
      */
-    private function execute(MinimumStrictCoverage $minimumStrictCoverage, $errorMessage)
+    private function execute(MinimumStrictCoverage $minimumStrictCoverage, $errorMessage, $enableFaces)
     {
         $outputMessage = new PreCommitOutputWriter(self::EXECUTE_MESSAGE);
         $this->output->write($outputMessage->getMessage());
-        $currentCoverage = $this->strictCoverageTool->run($minimumStrictCoverage, $errorMessage);
+        $currentCoverage = $this->strictCoverageTool->run($minimumStrictCoverage, $errorMessage, $enableFaces);
         $this->output->writeln($outputMessage->getSuccessfulMessage() . $this->printCurrentCoverage($currentCoverage));
     }
 
@@ -55,12 +59,15 @@ class StrictCoverageToolHandler implements CommandHandlerInterface
 
     /**
      * @param CommandInterface|StrictCoverage $command
+     *
+     * @throws InvalidStrictCoverageException
      */
     public function handle(CommandInterface $command)
     {
         $this->execute(
             new MinimumStrictCoverage($command->getMinimumCoverage()),
-            $command->getErrorMessage()
+            $command->getErrorMessage(),
+            $command->isEnableFaces()
         );
     }
 }

--- a/src/PhpGitHooks/Module/PhpUnit/Service/StrictCoverageTool.php
+++ b/src/PhpGitHooks/Module/PhpUnit/Service/StrictCoverageTool.php
@@ -34,16 +34,17 @@ class StrictCoverageTool
     /**
      * @param MinimumStrictCoverage $minimumStrictCoverage
      * @param string $errorMessage
+     * @param bool $enableFaces
      *
      * @return float
      * @throws InvalidStrictCoverageException
      */
-    public function run(MinimumStrictCoverage $minimumStrictCoverage, $errorMessage)
+    public function run(MinimumStrictCoverage $minimumStrictCoverage, $errorMessage, $enableFaces)
     {
         $currentCoverage = $this->strictCoverageProcessor->process();
 
         if ($minimumStrictCoverage->value() > $currentCoverage) {
-            $this->output->writeln(BadJobLogoResponse::paint($errorMessage));
+            $this->output->writeln(BadJobLogoResponse::paint($errorMessage, $enableFaces));
 
             throw new InvalidStrictCoverageException($currentCoverage, $minimumStrictCoverage->value());
         }

--- a/src/PhpGitHooks/Module/PhpUnit/Tests/Behaviour/PhpUnitToolHandlerTest.php
+++ b/src/PhpGitHooks/Module/PhpUnit/Tests/Behaviour/PhpUnitToolHandlerTest.php
@@ -28,6 +28,7 @@ class PhpUnitToolHandlerTest extends PhpUnitUnitTestCase
 
     /**
      * @test
+     * @throws PhpUnitViolationException
      */
     public function itShouldThrowsException()
     {
@@ -39,19 +40,21 @@ class PhpUnitToolHandlerTest extends PhpUnitUnitTestCase
 
         $this->shouldWriteLnOutput($outputMessage->getMessage());
         $this->shouldProcessPhpUnit($options, false);
-        $this->shouldWriteLnOutput(BadJobLogoResponse::paint($errorMessage));
+        $this->shouldWriteLnOutput(BadJobLogoResponse::paint($errorMessage, true));
 
         $this->phpUnitToolCommandHandler->handle(
             new PhpUnitTool(
                 true,
                 $options,
-                $errorMessage
+                $errorMessage,
+                true
             )
         );
     }
 
     /**
      * @test
+     * @throws PhpUnitViolationException
      */
     public function itShouldExecuteAndWorksFine()
     {
@@ -66,7 +69,8 @@ class PhpUnitToolHandlerTest extends PhpUnitUnitTestCase
             new PhpUnitTool(
                 true,
                 $options,
-                $errorMessage
+                $errorMessage,
+                true
             )
         );
     }

--- a/src/PhpGitHooks/Module/PhpUnit/Tests/Behaviour/StrictCoverageToolHandlerTest.php
+++ b/src/PhpGitHooks/Module/PhpUnit/Tests/Behaviour/StrictCoverageToolHandlerTest.php
@@ -37,6 +37,7 @@ class StrictCoverageToolHandlerTest extends PhpUnitUnitTestCase
 
     /**
      * @test
+     * @throws InvalidStrictCoverageException
      */
     public function itShouldThrowsException()
     {
@@ -47,14 +48,15 @@ class StrictCoverageToolHandlerTest extends PhpUnitUnitTestCase
 
         $this->shouldWriteOutput($outputMessage->getMessage());
         $this->shouldProcessStrictCoverage(0.00);
-        $this->shouldWriteLnOutput(BadJobLogoResponse::paint($this->errorMessage));
+        $this->shouldWriteLnOutput(BadJobLogoResponse::paint($this->errorMessage, true));
 
-        $command = new StrictCoverage($minimumStrictCoverage->value(), $this->errorMessage);
+        $command = new StrictCoverage($minimumStrictCoverage->value(), $this->errorMessage, true);
         $this->strictCoverageToolCommandHandler->handle($command);
     }
 
     /**
      * @test
+     * @throws InvalidStrictCoverageException
      */
     public function itShouldWorksFine()
     {
@@ -72,7 +74,7 @@ class StrictCoverageToolHandlerTest extends PhpUnitUnitTestCase
             )
         );
 
-        $command = new StrictCoverage($minimumStrictCoverage->value(), $this->errorMessage);
+        $command = new StrictCoverage($minimumStrictCoverage->value(), $this->errorMessage, true);
         $this->strictCoverageToolCommandHandler->handle($command);
     }
 


### PR DESCRIPTION
fixes #91 
add configuration option `enable-faces` to the `messages` sections of `pre-commit` and `pre-push` configuration.
adds possibility to turn off printing ascii graphic containing faces from bad & good messages.